### PR TITLE
設定更新

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
         emacs_version:
-          - 28.1
-          - 28.2
           - 29.1
           - 29.2
           - 29.3

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ var/pcache/
 /async-bytecomp.log
 /bookmarks
 /conf/local-init.el
-/forge-database.sqlite
 /history
 /network-security.data
 /org-recent-headings

--- a/Cask
+++ b/Cask
@@ -145,6 +145,7 @@
 (depends-on "smex")
 (depends-on "spacemacs-theme")
 (depends-on "spacious-padding")
+(depends-on "spray")
 (depends-on "sql-indent")
 (depends-on "sqlup-mode")
 (depends-on "swiper")

--- a/Cask
+++ b/Cask
@@ -55,7 +55,6 @@
 (depends-on "fish-mode")
 (depends-on "flycheck")
 (depends-on "flycheck-cask")
-(depends-on "forge")
 (depends-on "git-gutter")
 (depends-on "git-link")
 (depends-on "git-timemachine")

--- a/conf/index.el
+++ b/conf/index.el
@@ -1915,6 +1915,27 @@ How to send a bug report:
   :init
   (all-the-icons-completion-mode +1))
 
+(use-package tabnine
+  :commands (tabnine-start-process)
+  :hook (prog-mode . tabnine-mode)
+  :straight t
+  :diminish "⌬"
+  :custom
+  (tabnine-wait 1)
+  (tabnine-minimum-prefix-length 0)
+  :hook (kill-emacs . tabnine-kill-process)
+  :config
+  (tabnine-start-process)
+  :bind
+  (:map  tabnine-completion-map
+	 ("<tab>" . tabnine-accept-completion)
+	 ("TAB" . tabnine-accept-completion)
+	 ("M-f" . tabnine-accept-completion-by-word)
+	 ("M-<return>" . tabnine-accept-completion-by-line)
+	 ("C-g" . tabnine-clear-overlay)
+	 ("M-[" . tabnine-previous-completion)
+	 ("M-]" . tabnine-next-completion)))
+
 (require 'lispy)
 (add-hook 'emacs-lisp-mode-hook (lambda () (lispy-mode 1)))
 

--- a/conf/index.el
+++ b/conf/index.el
@@ -1880,6 +1880,8 @@ How to send a bug report:
 (require 'corfu)
 (global-corfu-mode)
 
+(corfu-popupinfo-mode)
+
 (setq corfu-auto t)
 (setq corfu-auto-prefix 3)
 (setq corfu-count 15)

--- a/conf/index.el
+++ b/conf/index.el
@@ -2318,7 +2318,7 @@ How to send a bug report:
 ;;           (lambda ()
 ;;             (start-process-shell-command
 ;;              "xrandr" nil "xrandr --output HDMI-1 --mode 1920x1080 --same-as eDP-1 --auto")))
-(exwm-randr-enable)
+;; (exwm-randr-enable)
 
 (defvar kd/polybar-process nil
   "Holds the process of the running Polybar instance, if any")

--- a/conf/index.el
+++ b/conf/index.el
@@ -1139,7 +1139,7 @@ How to send a bug report:
   (require 'forge))
 
 (global-git-gutter-mode 1)
-(global-set-key (kbd "C-c C-v") 'git-gutter-show-hunk-inline-at-point)
+(global-set-key (kbd "C-c C-v") 'git-gutter:popup-hunk)
 
 ;; http://www.modernemacs.com/post/pretty-magit/
 (defun kd/magit-commit-prompt ()
@@ -2387,8 +2387,8 @@ How to send a bug report:
 
      "Git"
      (("g" git-link)
-      (">" git-gutter-next-hunk)
-      ("<" git-gutter-previous-hunk)
+      (">" git-gutter:next-hunk)
+      ("<" git-gutter:previous-hunk)
       ("@" git-timemachine))
 
      "Edit"

--- a/conf/index.el
+++ b/conf/index.el
@@ -159,7 +159,7 @@
      '(org-meta-line ((t (:inherit (font-lock-comment-face fixed-pitch)))))
      '(org-property-value ((t (:inherit fixed-pitch))) t)
      '(org-special-keyword ((t (:inherit (font-lock-comment-face fixed-pitch)))))
-     '(org-table ((t (:inherit fixed-pitch :foreground "#f5f5f5"))))
+     '(org-table ((t (:inherit fixed-pitch))))
      '(org-tag ((t (:inherit (shadow fixed-pitch) :weight bold :height 0.8))))
      '(org-verbatim ((t (:inherit (shadow fixed-pitch)))))
      '(org-block-begin-line ((t (:inherit org-block))))))
@@ -2174,6 +2174,82 @@ How to send a bug report:
 (spacious-padding-mode)
 
 (require 'exwm)
+
+;;; exwm-config.el --- Predefined configurations  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2015-2024 Free Software Foundation, Inc.
+
+;; Author: Chris Feng <chris.w.feng@gmail.com>
+
+;; This file is part of GNU Emacs.
+
+;; GNU Emacs is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This module contains an example configuration of EXWM.  Do not require this
+;; file directly in your user configuration.  Instead take it as inspiration and
+;; copy the relevant settings to your user configuration.
+
+;;; Code:
+
+(require 'exwm)
+
+(defun exwm-config-example ()
+  "Default configuration of EXWM."
+  ;; Set the initial workspace number.
+  (unless (get 'exwm-workspace-number 'saved-value)
+    (setq exwm-workspace-number 4))
+  ;; Make class name the buffer name
+  (add-hook 'exwm-update-class-hook
+            (lambda ()
+              (exwm-workspace-rename-buffer exwm-class-name)))
+  ;; Global keybindings.
+  (unless (get 'exwm-input-global-keys 'saved-value)
+    (setq exwm-input-global-keys
+          `(
+            ;; 's-r': Reset (to line-mode).
+            ([?\s-r] . exwm-reset)
+            ;; 's-w': Switch workspace.
+            ([?\s-w] . exwm-workspace-switch)
+            ;; 's-&': Launch application.
+            ([?\s-&] . (lambda (command)
+                         (interactive (list (read-shell-command "$ ")))
+                         (start-process-shell-command command nil command)))
+            ;; 's-N': Switch to certain workspace.
+            ,@(mapcar (lambda (i)
+                        `(,(kbd (format "s-%d" i)) .
+                          (lambda ()
+                            (interactive)
+                            (exwm-workspace-switch-create ,i))))
+                      (number-sequence 0 9)))))
+  ;; Line-editing shortcuts
+  (unless (get 'exwm-input-simulation-keys 'saved-value)
+    (setq exwm-input-simulation-keys
+          '(([?\C-b] . [left])
+            ([?\C-f] . [right])
+            ([?\C-p] . [up])
+            ([?\C-n] . [down])
+            ([?\C-a] . [home])
+            ([?\C-e] . [end])
+            ([?\M-v] . [prior])
+            ([?\C-v] . [next])
+            ([?\C-d] . [delete])
+            ([?\C-k] . [S-end delete]))))
+  ;; Enable EXWM
+  (exwm-enable)
+  )
 
 (setq exwm-replace t)
 

--- a/conf/index.el
+++ b/conf/index.el
@@ -378,7 +378,7 @@ How to send a bug report:
 (global-set-key (kbd "C-x C-z") 'open-junk-file)
 
 (require 'org-superstar)
-;; (add-hook 'org-mode-hook (lambda () (org-superstar-mode 1)))
+(add-hook 'org-mode-hook (lambda () (org-superstar-mode 1)))
 ;; (setq org-superstar-headline-bullets-list '("🙐" "🙑" "🙒" "🙓" "🙔" "🙕" "🙖" "🙗"))
 ;; (setq org-superstar-headline-bullets-list '("◉" "○" "●" "✿" "✸"))
 ;; (setq org-superstar-item-bullet-alist '((?* . ?•)
@@ -466,17 +466,18 @@ How to send a bug report:
 (setq org-alert-notification-title "Reminder")
 (org-alert-enable)
 
+(add-to-list 'load-path "~/.emacs.d/vendor/denote-2.0.0")
+(require 'denote)
 (require 'denote-org-dblock)
 
-  (setq denote-directory (expand-file-name "~/roam"))
-  (setq denote-known-keywords '("permanent" "book" "structure" "project" "wiki" "essay"))
+(setq denote-directory (expand-file-name "~/roam"))
+(setq denote-known-keywords '("permanent" "book" "structure" "project" "wiki" "essay"))
+(define-key global-map (kbd "C-c d") 'denote-create-note)
 
-  (define-key global-map (kbd "C-c d") 'denote-create-note)
-
-  ;; カスタムテンプレート
+;; カスタムテンプレート
   ;; roamで表示できるIDを追加
   (setq denote-org-front-matter
-        ":properties:
+              ":properties:
 :ID: %4$s
 :end:
 #+title:      KDOC n: %1$s
@@ -485,11 +486,12 @@ How to send a bug report:
 #+identifier: %4$s
 \n")
 
-(use-package denote-menu
-  :straight (:host github :repo "namilus/denote-menu"))
-
 (setq denote-templates
       `((entry . ,(f-read-text "~/.emacs.d/resources/entry.org"))))
+
+(setq denote-excluded-files-regexp ".*html$")
+
+(setq denote-rename-confirmations nil)
 
 (define-key global-map "\C-cl" 'org-store-link)
 (define-key global-map "\C-ca" 'org-agenda)
@@ -1871,8 +1873,7 @@ How to send a bug report:
   :config
   (defun my/eglot-capf ()
     (setq-local completion-at-point-functions
-                (list (cape-super-capf
-                      #'tempel-complete
+                (list (cape-capf-super
                       #'eglot-completion-at-point)
                       #'cape-keyword
                       #'cape-dabbrev
@@ -2760,7 +2761,7 @@ and source-file directory for your debugger."
             (setq dlv-command (concat gud-dlv-command-name " test -- -test.run='^$' -test.bench=" current-bench-name)))
            (t
             (setq gud-buffer-name "*gud-debug*")
-            (setq dlv-command (concat gud-dlv-command-name " debug"))))
+            (setq dlv-command (concat gud-dlv-command-name " debug -- /home/orange/Project/test"))))
 
           ;; stop the current active dlv session if any
           (let ((gud-buffer (get-buffer gud-buffer-name)))

--- a/conf/index.el
+++ b/conf/index.el
@@ -2774,3 +2774,6 @@ and source-file directory for your debugger."
 
 (provide 'go-dlv)
 ;;; go-dlv.el ends here
+
+(require 'spray)
+(setq spray-wpm 200)

--- a/conf/index.el
+++ b/conf/index.el
@@ -2382,7 +2382,8 @@ How to send a bug report:
       ("c" recompile "recompile")
       ("!" org-pomodoro "start pomodoro")
       ("n" elfeed "elfeed")
-      ("u" kd/set-proxy-mode-manual "use proxy"))
+      ("u" kd/set-proxy-mode-manual "use proxy")
+      ("h" eldoc-doc-buffer "eldoc at pos"))
 
      "Git"
      (("g" git-link)

--- a/conf/index.el
+++ b/conf/index.el
@@ -1924,8 +1924,6 @@ How to send a bug report:
   (tabnine-wait 1)
   (tabnine-minimum-prefix-length 0)
   :hook (kill-emacs . tabnine-kill-process)
-  :config
-  (tabnine-start-process)
   :bind
   (:map  tabnine-completion-map
 	 ("<tab>" . tabnine-accept-completion)
@@ -2198,8 +2196,7 @@ How to send a bug report:
             ([?\C-d] . [delete])
             ([?\C-k] . [S-end delete]))))
   ;; Enable EXWM
-  (exwm-enable)
-  )
+  (exwm-enable))
 
 (setq exwm-replace t)
 
@@ -2308,6 +2305,8 @@ How to send a bug report:
 (when window-system
   (progn
     (exwm-config-example)
+
+    (tabnine-start-process)
     ;; (kd/set-init)
     ))
 

--- a/conf/index.el
+++ b/conf/index.el
@@ -1137,9 +1137,6 @@ How to send a bug report:
 (require 'magit)
 (global-set-key (kbd "C-x g") 'magit-status)
 
-(with-eval-after-load 'magit
-  (require 'forge))
-
 (global-git-gutter-mode 1)
 (global-set-key (kbd "C-c C-v") 'git-gutter:popup-hunk)
 

--- a/conf/index.org
+++ b/conf/index.org
@@ -2651,6 +2651,31 @@ verticoは検索UIを提供するパッケージ。
   (all-the-icons-completion-mode +1))
 #+end_src
 
+* tabnine
+
+#+begin_src emacs-lisp
+(use-package tabnine
+  :commands (tabnine-start-process)
+  :hook (prog-mode . tabnine-mode)
+  :straight t
+  :diminish "⌬"
+  :custom
+  (tabnine-wait 1)
+  (tabnine-minimum-prefix-length 0)
+  :hook (kill-emacs . tabnine-kill-process)
+  :config
+  (tabnine-start-process)
+  :bind
+  (:map  tabnine-completion-map
+	 ("<tab>" . tabnine-accept-completion)
+	 ("TAB" . tabnine-accept-completion)
+	 ("M-f" . tabnine-accept-completion-by-word)
+	 ("M-<return>" . tabnine-accept-completion-by-line)
+	 ("C-g" . tabnine-clear-overlay)
+	 ("M-[" . tabnine-previous-completion)
+	 ("M-]" . tabnine-next-completion)))
+#+end_src
+
 * emacs Lisp
 ** rispy
 rispyはリストの操作をやりやすくするパッケージ。

--- a/conf/index.org
+++ b/conf/index.org
@@ -3181,7 +3181,7 @@ EXWMはEmacs上で動くウィンドウマネージャ。
   ;;           (lambda ()
   ;;             (start-process-shell-command
   ;;              "xrandr" nil "xrandr --output HDMI-1 --mode 1920x1080 --same-as eDP-1 --auto")))
-  (exwm-randr-enable)
+  ;; (exwm-randr-enable)
 #+end_src
 
 randr関係の修正をしたときは、 ~(exwm-randr-refresh)~ を実行して反映する。例えば、画面と対応したワークスペースを変更したとき。

--- a/conf/index.org
+++ b/conf/index.org
@@ -494,7 +494,7 @@ How to send a bug report:
 #+caption: 見出しをいい感じにする
 #+begin_src emacs-lisp
   (require 'org-superstar)
-  ;; (add-hook 'org-mode-hook (lambda () (org-superstar-mode 1)))
+  (add-hook 'org-mode-hook (lambda () (org-superstar-mode 1)))
   ;; (setq org-superstar-headline-bullets-list '("🙐" "🙑" "🙒" "🙓" "🙔" "🙕" "🙖" "🙗"))
   ;; (setq org-superstar-headline-bullets-list '("◉" "○" "●" "✿" "✸"))
   ;; (setq org-superstar-item-bullet-alist '((?* . ?•)
@@ -647,19 +647,25 @@ org-alertはorg scheduleの項目を時間経過で通知してくれるパッ�
 ** denote
 denoteはシンプルなノートパッケージ。
 
+#+caption: v3に追従できてないのでv2に固定する
+#+begin_src emacs-lisp
+  (add-to-list 'load-path "~/.emacs.d/vendor/denote-2.0.0")
+  (require 'denote)
+  (require 'denote-org-dblock)
+#+end_src
+
 #+caption: 設定
 #+begin_src emacs-lisp
-  (require 'denote-org-dblock)
-
   (setq denote-directory (expand-file-name "~/roam"))
   (setq denote-known-keywords '("permanent" "book" "structure" "project" "wiki" "essay"))
-
   (define-key global-map (kbd "C-c d") 'denote-create-note)
+#+end_src
 
+#+begin_src emacs-lisp
   ;; カスタムテンプレート
   ;; roamで表示できるIDを追加
   (setq denote-org-front-matter
-        ":properties:
+              ":properties:
 :ID: %4$s
 :end:
 #+title:      KDOC n: %1$s
@@ -669,16 +675,20 @@ denoteはシンプルなノートパッケージ。
 \n")
 #+end_src
 
-#+caption: denoteのメニュー表示する
-#+begin_src emacs-lisp
-  (use-package denote-menu
-    :straight (:host github :repo "namilus/denote-menu"))
-#+end_src
-
 #+caption: denoteのテンプレートを設定する
 #+begin_src emacs-lisp
   (setq denote-templates
         `((entry . ,(f-read-text "~/.emacs.d/resources/entry.org"))))
+#+end_src
+
+#+caption: 候補に出ないようにする
+#+begin_src emacs-lisp
+  (setq denote-excluded-files-regexp ".*html$")
+#+end_src
+
+#+caption: 確認を非表示にする
+#+begin_src emacs-lisp
+  (setq denote-rename-confirmations nil)
 #+end_src
 
 ** org-agenda
@@ -2594,8 +2604,7 @@ verticoは検索UIを提供するパッケージ。
     :config
     (defun my/eglot-capf ()
       (setq-local completion-at-point-functions
-                  (list (cape-super-capf
-                        #'tempel-complete
+                  (list (cape-capf-super
                         #'eglot-completion-at-point)
                         #'cape-keyword
                         #'cape-dabbrev

--- a/conf/index.org
+++ b/conf/index.org
@@ -1669,7 +1669,7 @@ Mermaid JSはテキストから図を描画するライブラリ。
 #+caption: git-gutter-mode
 #+begin_src emacs-lisp
   (global-git-gutter-mode 1)
-  (global-set-key (kbd "C-c C-v") 'git-gutter-show-hunk-inline-at-point)
+  (global-set-key (kbd "C-c C-v") 'git-gutter:popup-hunk)
 #+end_src
 
 #+caption: commit時にconvential commitを選択する
@@ -3272,8 +3272,8 @@ Hydraはカスタマイズ可能なキー表示を追加するパッケージ。
 
        "Git"
        (("g" git-link)
-        (">" git-gutter-next-hunk)
-        ("<" git-gutter-previous-hunk)
+        (">" git-gutter:next-hunk)
+        ("<" git-gutter:previous-hunk)
         ("@" git-timemachine))
 
        "Edit"

--- a/conf/index.org
+++ b/conf/index.org
@@ -248,7 +248,7 @@ org-modeはEmacsのキラーアプリの1つ。パッケージ名であり、フ
      '(org-meta-line ((t (:inherit (font-lock-comment-face fixed-pitch)))))
      '(org-property-value ((t (:inherit fixed-pitch))) t)
      '(org-special-keyword ((t (:inherit (font-lock-comment-face fixed-pitch)))))
-     '(org-table ((t (:inherit fixed-pitch :foreground "#f5f5f5"))))
+     '(org-table ((t (:inherit fixed-pitch))))
      '(org-tag ((t (:inherit (shadow fixed-pitch) :weight bold :height 0.8))))
      '(org-verbatim ((t (:inherit (shadow fixed-pitch)))))
      '(org-block-begin-line ((t (:inherit org-block))))))
@@ -3007,6 +3007,85 @@ EXWMはEmacs上で動くウィンドウマネージャ。
 #+caption: require
 #+begin_src emacs-lisp
   (require 'exwm)
+#+end_src
+
+#+caption: ライブラリから外されたのでコピーが推奨されている。https://github.com/emacs-exwm/exwm/blob/fa3393806c3e7e3d6dc767cd7c0e29b8d4d0a716/exwm-config.el
+#+begin_src emacs-lisp
+  ;;; exwm-config.el --- Predefined configurations  -*- lexical-binding: t -*-
+
+  ;; Copyright (C) 2015-2024 Free Software Foundation, Inc.
+
+  ;; Author: Chris Feng <chris.w.feng@gmail.com>
+
+  ;; This file is part of GNU Emacs.
+
+  ;; GNU Emacs is free software: you can redistribute it and/or modify
+  ;; it under the terms of the GNU General Public License as published by
+  ;; the Free Software Foundation, either version 3 of the License, or
+  ;; (at your option) any later version.
+
+  ;; GNU Emacs is distributed in the hope that it will be useful,
+  ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ;; GNU General Public License for more details.
+
+  ;; You should have received a copy of the GNU General Public License
+  ;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+  ;;; Commentary:
+
+  ;; This module contains an example configuration of EXWM.  Do not require this
+  ;; file directly in your user configuration.  Instead take it as inspiration and
+  ;; copy the relevant settings to your user configuration.
+
+  ;;; Code:
+
+  (require 'exwm)
+
+  (defun exwm-config-example ()
+    "Default configuration of EXWM."
+    ;; Set the initial workspace number.
+    (unless (get 'exwm-workspace-number 'saved-value)
+      (setq exwm-workspace-number 4))
+    ;; Make class name the buffer name
+    (add-hook 'exwm-update-class-hook
+              (lambda ()
+                (exwm-workspace-rename-buffer exwm-class-name)))
+    ;; Global keybindings.
+    (unless (get 'exwm-input-global-keys 'saved-value)
+      (setq exwm-input-global-keys
+            `(
+              ;; 's-r': Reset (to line-mode).
+              ([?\s-r] . exwm-reset)
+              ;; 's-w': Switch workspace.
+              ([?\s-w] . exwm-workspace-switch)
+              ;; 's-&': Launch application.
+              ([?\s-&] . (lambda (command)
+                           (interactive (list (read-shell-command "$ ")))
+                           (start-process-shell-command command nil command)))
+              ;; 's-N': Switch to certain workspace.
+              ,@(mapcar (lambda (i)
+                          `(,(kbd (format "s-%d" i)) .
+                            (lambda ()
+                              (interactive)
+                              (exwm-workspace-switch-create ,i))))
+                        (number-sequence 0 9)))))
+    ;; Line-editing shortcuts
+    (unless (get 'exwm-input-simulation-keys 'saved-value)
+      (setq exwm-input-simulation-keys
+            '(([?\C-b] . [left])
+              ([?\C-f] . [right])
+              ([?\C-p] . [up])
+              ([?\C-n] . [down])
+              ([?\C-a] . [home])
+              ([?\C-e] . [end])
+              ([?\M-v] . [prior])
+              ([?\C-v] . [next])
+              ([?\C-d] . [delete])
+              ([?\C-k] . [S-end delete]))))
+    ;; Enable EXWM
+    (exwm-enable)
+    )
 #+end_src
 
 #+caption: ほかのウィンドウマネージャを置き換えて起動する

--- a/conf/index.org
+++ b/conf/index.org
@@ -3725,3 +3725,11 @@ and source-file directory for your debugger."
 (provide 'go-dlv)
 ;;; go-dlv.el ends here
 #+end_src
+* spray
+
+sprayは速読表示してくれる拡張。
+
+#+begin_src emacs-lisp
+  (require 'spray)
+  (setq spray-wpm 200)
+#+end_src

--- a/conf/index.org
+++ b/conf/index.org
@@ -2300,18 +2300,20 @@ goの設定。
 #+caption: デバッガ
 #+begin_src emacs-lisp
   (use-package dap-mode
-      :after lsp-mode
-      :hook
-      (lsp-mode . dap-mode)
-      (lsp-mode . dap-ui-mode)
-      :config
-      (dap-mode 1)
-      (require 'dap-hydra)
-      (require 'dap-dlv-go))
-
+    :config
+    (dap-mode 1)
+    (require 'dap-hydra)
+    (require 'dap-dlv-go))
   (setq dap-print-io t)
-  (setq lsp-gopls-server-path "~/go/bin/gopls")
   (setq dap-dlv-go-delve-path "~/go/bin/dlv")
+
+  (use-package posframe
+    ;; Posframe is a pop-up tool that must be manually installed for dap-mode
+    )
+
+  (use-package dap-ui
+    :config
+    (dap-ui-mode 1))
 #+end_src
 
 #+caption: go-eldoc
@@ -2487,114 +2489,6 @@ web-modeはhtmlライクな複数の言語に対応するモード。
   (require 'typescript-mode)
   (add-to-list 'auto-mode-alist '("\\.ts\\'" . typescript-mode))
 #+end_src
-* LSP
-lsp-modeはLSPを使えるようにするパッケージ。
-
-#+caption: metalがインストールできないので確認を無効化する
-#+begin_src emacs-lisp
-  (setq lsp-verify-signature nil)
-#+end_src
-
-#+caption: 言語共通設定
-#+begin_src emacs-lisp
-  (use-package flycheck
-    :init (global-flycheck-mode))
-
-  (use-package lsp-mode
-    :custom
-    (lsp-completion-provider :none)
-    (lsp-prefer-flymake nil)
-    (lsp-print-io nil)
-    (lsp-trace nil)
-    (lsp-print-performance nil)
-    (lsp-auto-guess-root t)
-    (lsp-document-sync-method 'incremental)
-    (lsp-response-timeout 5)
-    :init
-    (defun my/lsp-mode-setup-completion ()
-      (setf (alist-get 'styles (alist-get 'lsp-capf completion-category-defaults))
-            '(orderless))) ;; Configure orderless
-    :hook
-    (scala-mode . lsp)
-    (clojure-mode . lsp)
-    (c-mode . lsp)
-    (c++-mode . lsp)
-    (rust-mode . lsp)
-    (go-mode . lsp)
-    (lsp-mode . lsp-lens-mode)
-    (lsp-mode . lsp-completion-mode)
-    (lsp-mode . lsp-ui-mode)
-    (lsp-completion-mode . my/lsp-mode-setup-completion)
-    :config
-    ;; Uncomment following section if you would like to tune lsp-mode performance according to
-    ;; https://emacs-lsp.github.io/lsp-mode/page/performance/
-          (setq gc-cons-threshold 100000000) ;; 100mb
-          (setq read-process-output-max (* 1024 1024 10)) ;; 10mb
-          (setq lsp-idle-delay 0.500)
-          (setq lsp-log-io nil)
-    )
-#+end_src
-
-#+caption: scala用を設定する
-#+begin_src emacs-lisp
-  ;; (use-package scala-mode
-  ;;   :interpreter
-  ;;   ("scala" . scala-mode))
-
-  ;; ;; Enable sbt mode for executing sbt commands
-  ;; (use-package sbt-mode
-  ;;   :commands sbt-start sbt-command
-  ;;   :config
-  ;;   ;; WORKAROUND: https://github.com/ensime/emacs-sbt-mode/issues/31
-  ;;   ;; allows using SPACE when in the minibuffer
-  ;;   (substitute-key-definition
-  ;;    'minibuffer-complete-word
-  ;;    'self-insert-command
-  ;;    minibuffer-local-completion-map)
-  ;;   ;; sbt-supershell kills sbt-mode:  https://github.com/hvesalai/emacs-sbt-mode/issues/152
-  ;;   (setq sbt:program-options '("-Dsbt.supershell=false"))
-  ;;   )
-
-  ;; (use-package lsp-metals
-  ;;   :ensure t
-  ;;   :custom
-  ;;   ;; Metals claims to support range formatting by default but it supports range
-  ;;   ;; formatting of multiline strings only. You might want to disable it so that
-  ;;   ;; emacs can use indentation provided by scala-mode.
-  ;;   (lsp-metals-server-args '("-J-Dmetals.allow-multiline-string-formatting=off"))
-  ;;   :hook (scala-mode . lsp))
-#+end_src
-
-使ってない。
-
-#+caption: ドキュメントをホバー表示できるようにする
-#+begin_src emacs-lisp
-  (use-package lsp-ui
-    :custom
-    (lsp-ui-doc-enable t)
-    (lsp-ui-doc-header t)
-    (lsp-ui-doc-include-signature t)
-    (lsp-ui-doc-max-width 150)
-    (lsp-ui-doc-max-height 30)
-    (lsp-ui-peek-enable t))
-#+end_src
-
-#+caption: snippetを挿入する
-#+begin_src emacs-lisp
-  (use-package yasnippet)
-#+end_src
-
-#+caption: DAPデバッガーを使えるようにする
-#+begin_src emacs-lisp
-  (use-package posframe
-    ;; Posframe is a pop-up tool that must be manually installed for dap-mode
-    )
-
-  (use-package dap-ui
-    :config
-    (dap-ui-mode 1))
-#+end_src
-
 * corfu
 corfuはシンプルな補完を提供するパッケージ。
 
@@ -2655,46 +2549,59 @@ verticoは検索UIを提供するパッケージ。
 
 #+caption: その他の連携パッケージ
 #+begin_src emacs-lisp
+  ;; 補完インターフェース
   (require 'vertico)
   (vertico-mode)
   (setq vertico-count 20)
 
+  ;; 上ディレクトリに移動できるようにする
   (require 'vertico-directory)
   (define-key vertico-map (kbd "C-l") #'vertico-directory-up)
   (define-key vertico-map "\r" #'vertico-directory-enter)  ;; enter dired
   (define-key vertico-map "\d" #'vertico-directory-delete-char)
 
+  ;; verticoに情報追加する
   (require 'marginalia)
   (marginalia-mode +1)
   ;; marginalia-annotatorsをサイクルする
   (define-key minibuffer-local-map (kbd "C-M-a") #'marginalia-cycle)
 
+  ;; 絞り込みロジック
   (require 'orderless)
   (setq completion-styles '(orderless partial-completion))
-  (setq completion-category-defaults nil)
-  (setq completion-category-overrides nil)
-
   (orderless-define-completion-style orderless+initialism
     (orderless-matching-styles '(orderless-initialism ;;一番最初にinitializm
                                  orderless-literal  ;;次にリテラルマッチ
                                  orderless-regexp)))
-
-  ;; (setq completion-category-defaults nil)
-  (setq completion-category-overrides
-        '((eglot (styles orderless+initialism))
-          (command (styles orderless+initialism))
-          (symbol (styles orderless+initialism))
-          (variable (styles orderless+initialism))))
-  (setq orderless-component-separator #'orderless-escapable-split-on-space)
+  ;; (setq completion-category-overrides
+  ;;       '((eglot (styles orderless+initialism))
+  ;;         (command (styles orderless+initialism))
+  ;;         (symbol (styles orderless+initialism))
+  ;;         (variable (styles orderless+initialism))))
+  ;; (setq orderless-component-separator #'orderless-escapable-split-on-space)
 
   (require 'cape)
-  (add-to-list 'completion-at-point-functions #'cape-file)
-  (add-to-list 'completion-at-point-functions #'cape-tex)
-  (add-to-list 'completion-at-point-functions #'cape-dabbrev)
-  (add-to-list 'completion-at-point-functions #'cape-keyword)
-  (add-to-list 'completion-at-point-functions #'cape-abbrev)
-  (add-to-list 'completion-at-point-functions #'cape-ispell)
-  (add-to-list 'completion-at-point-functions #'cape-symbol)
+#+end_src
+
+#+caption: eglot
+#+begin_src emacs-lisp
+  (use-package eglot
+    :bind (nil
+           :map eglot-mode-map
+           ("C-c a" . eglot-code-actions))
+    :hook
+    (go-mode . eglot-ensure)
+    :config
+    (defun my/eglot-capf ()
+      (setq-local completion-at-point-functions
+                  (list (cape-super-capf
+                        #'tempel-complete
+                        #'eglot-completion-at-point)
+                        #'cape-keyword
+                        #'cape-dabbrev
+                        #'cape-file)
+                  ))
+    (add-hook 'eglot-managed-mode-hook #'my/eglot-capf))
 #+end_src
 
 #+caption: kind-icon
@@ -3241,7 +3148,6 @@ EXWMはEmacs上で動くウィンドウマネージャ。
   ;;           (lambda ()
   ;;             (start-process-shell-command
   ;;              "xrandr" nil "xrandr --output HDMI-1 --mode 1920x1080 --same-as eDP-1 --auto")))
-  (exwm-enable)
   (exwm-randr-enable)
 #+end_src
 

--- a/conf/index.org
+++ b/conf/index.org
@@ -3267,7 +3267,8 @@ Hydraはカスタマイズ可能なキー表示を追加するパッケージ。
         ("c" recompile "recompile")
         ("!" org-pomodoro "start pomodoro")
         ("n" elfeed "elfeed")
-        ("u" kd/set-proxy-mode-manual "use proxy"))
+        ("u" kd/set-proxy-mode-manual "use proxy")
+        ("h" eldoc-doc-buffer "eldoc at pos"))
 
        "Git"
        (("g" git-link)

--- a/conf/index.org
+++ b/conf/index.org
@@ -1670,9 +1670,6 @@ Mermaid JSはテキストから図を描画するライブラリ。
 #+begin_src emacs-lisp
   (require 'magit)
   (global-set-key (kbd "C-x g") 'magit-status)
-
-  (with-eval-after-load 'magit
-    (require 'forge))
 #+end_src
 
 

--- a/conf/index.org
+++ b/conf/index.org
@@ -2606,6 +2606,11 @@ corfuはシンプルな補完を提供するパッケージ。
   (global-corfu-mode)
 #+end_src
 
+#+caption: 補完の隣にドキュメント表示する
+#+begin_src emacs-lisp
+  (corfu-popupinfo-mode)
+#+end_src
+
 #+caption: 基本設定
 #+begin_src emacs-lisp
   (setq corfu-auto t)

--- a/conf/index.org
+++ b/conf/index.org
@@ -2663,8 +2663,6 @@ verticoは検索UIを提供するパッケージ。
   (tabnine-wait 1)
   (tabnine-minimum-prefix-length 0)
   :hook (kill-emacs . tabnine-kill-process)
-  :config
-  (tabnine-start-process)
   :bind
   (:map  tabnine-completion-map
 	 ("<tab>" . tabnine-accept-completion)
@@ -3021,8 +3019,7 @@ EXWMはEmacs上で動くウィンドウマネージャ。
               ([?\C-d] . [delete])
               ([?\C-k] . [S-end delete]))))
     ;; Enable EXWM
-    (exwm-enable)
-    )
+    (exwm-enable))
 #+end_src
 
 #+caption: ほかのウィンドウマネージャを置き換えて起動する
@@ -3160,6 +3157,8 @@ EXWMはEmacs上で動くウィンドウマネージャ。
   (when window-system
     (progn
       (exwm-config-example)
+
+      (tabnine-start-process)
       ;; (kd/set-init)
       ))
 #+end_src

--- a/vendor/denote-2.0.0/.dir-locals.el
+++ b/vendor/denote-2.0.0/.dir-locals.el
@@ -1,0 +1,4 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((emacs-lisp-mode . ((indent-tabs-mode . nil))))

--- a/vendor/denote-2.0.0/.gitignore
+++ b/vendor/denote-2.0.0/.gitignore
@@ -1,0 +1,5 @@
+*.elc
+*-autoloads.el
+*-pkg.el
+denote.info
+denote.texi

--- a/vendor/denote-2.0.0/CHANGELOG.org
+++ b/vendor/denote-2.0.0/CHANGELOG.org
@@ -1,0 +1,2830 @@
+#+title: Change log of Denote
+#+author: Protesilaos Stavrou
+#+email: info@protesilaos.com
+#+options: ':nil toc:nil num:nil author:nil email:nil
+
+This document contains the release notes for each tagged commit on the
+project's main git repository: <https://git.sr.ht/~protesilaos/denote>.
+
+The newest release is at the top.  For further details, please consult
+the manual: <https://protesilaos.com/emacs/denote>.
+
+* Version 2.0.0 on 2023-07-21
+:PROPERTIES:
+:CUSTOM_ID: h:3f17bf03-4c47-4410-abf8-1db4a0ac7775
+:END:
+
+This is the second major version of Denote, close to one year after
+its initial release.  The video demo I did back then remains relevant,
+even though lots of details have changed.
+
+** Notes have a new optional SIGNATURE field
+:PROPERTIES:
+:CUSTOM_ID: h:a3a9e14d-4132-47c0-a23c-cb008a141668
+:END:
+
+It is now possible to create notes that include a =SIGNATURE= field in
+their file name.  Either use the convenience command ~denote-signature~
+or configure the user option ~denote-prompts~ to affect what the ~denote~
+command should prompt for.
+
+Signatures are arbitrary strings of characters that enable the user to
+further qualify their documents.  One possible workflow is to write
+relational notes, such that =1a1= is the first extension of another
+note with a =1a= signature.
+
+The design of the =SIGNATURE= field is consistent with the Denote
+file-naming scheme.  The field separator is the double equals sign
+(~==~), while words that comprise the signature are joined together by
+a single equals sign.  As such, the user can prefix a search with an
+equals sign to match words in the =SIGNATURE=, just as they would use
+dashes for the =TITLE= and underscores for the =KEYWORDS=.
+
+[ Read the manual for the technicalities of the Denote file-naming
+  scheme.  This is not limited to "notes": any file can be named
+  accordingly (I do it with my videos, for example). ]
+
+Signatures are not included in a file's front matter.  This is a
+strategic decision to preserve backward compatibility, while not
+introducing a feature that has not enjoyed widespread usage.  I want
+to make signatures behave the same as the rest of the file name
+fields, though I am interested to learn how users employ them in their
+workflow.
+
+The signature extension was discussed at length on the GitHub mirror
+in issue 115: <https://github.com/protesilaos/denote/issues/115>.
+Thanks to Stefan Thesing, Mirko Hernandez, Noboru Ota (nobiot),
+Xiaoxing Hu, nbehrnd, Elias Storms, and 101scholar for helping me
+reason about this feature, understand its scope, and prototype its
+implementation.
+
+Also thanks to Alfredo Borrás and Jeremy Friesen for discussing with
+me the field delimiter of signatures on the mailing list:
+<https://lists.sr.ht/~protesilaos/denote/%3C2A597B4E-5F18-4D97-9457-B3C859DAA020%40zoho.eu%3E>.
+Thanks to Kai von Fintel for doing the same on the GitHub mirror in
+issue 147: <https://github.com/protesilaos/denote/issues/147>.
+
+Read the original announcement:
+<https://protesilaos.com/codelog/2023-03-20-emacs-denote-signature-feature/>.
+
+As part of the development, I fixed a case where
+~denote-rename-file-using-front-matter~ would fail if it could not
+find a signature
+  
+The idea is that we want the command to behave the way it always did
+when the file has no signature and to preserve the signature when it
+is present.
+
+Thanks to relict for reporting the issue on the mailing list:
+<https://lists.sr.ht/~protesilaos/denote/%3C87zg86lru9.fsf%40kotlak.com%3E>.
+
+** The rename commands avoid creating duplicate identifiers
+:PROPERTIES:
+:CUSTOM_ID: h:d24645a3-ad02-450c-b3d7-af7802aa0b26
+:END:
+
+Denote provides commands to rename an existing file to one that
+follows the Denote file-naming scheme (videos, PDFs, other text
+documents, ...).  Check, for example, the ~denote-rename-file~ and
+~denote-dired-rename-marked-files~.  The idea is to make everything
+easier to search.
+
+In prior versions, these commands could produce duplicate identifiers
+if the modification date of the underlying files was the same.  Such a
+scenario occurs when the files are modified programmatically, as with
+the =touch= command or the various =git= operations.
+
+Denote will now take care to increment the identifier until it becomes
+unique within the current scope.
+
+Thanks to Felipe Balbi for reporting this bug in issue 105 on the
+GitHub mirror: <https://github.com/protesilaos/denote/issues/105>.
+
+Thanks to Vedang Manerikar and Jean-Charles Bagneris for commenting on
+this feature on the mailing list:
+<https://lists.sr.ht/~protesilaos/denote/%3C87v8emeus0.fsf%40protesilaos.com%3E>.
+
+Thanks to Ashton Wiersdorf for noticing a mistake I made that caused a
+regression in ~denote-rename-file~:
+<https://lists.sr.ht/~protesilaos/denote/%3Cm2lefbbzl1.fsf%40wiersdorfmail.net%3E>.
+
+*** Optional arguments affect ~denote-dired-rename-marked-files~
+:PROPERTIES:
+:CUSTOM_ID: h:6ea998be-83dd-4c67-945c-11011372818f
+:END:
+
+The ~denote-dired-rename-marked-files~ now accepts two optional
+arguments.  When called interactively, these are interpreted as a
+single or double universal prefix argument (=C-u= by default, though
+do =M-x where-is= and search for ~universal-argument~).
+
+The first argument, named =SKIP-FRONT-MATTER-PROMPT=, skips the "yes
+or no" prompt requested at the outset of the operation, passing to it
+an affirmative response.  Thanks to Jay Rajput for asking the question
+that inspired me to implement this.  It was done in issue 155 on the
+GitHub mirror: <https://github.com/protesilaos/denote/issues/155>.
+
+The second argument, named =NO-UNIQUE-ID-CHECK=, will not perform any
+checks for potential duplicate identifiers.  The default is to check
+for duplicates and increment them such that they become unique.  The
+reason this optional argument exists is for those who want to speed up
+the process, perhaps because they know ahead of time all identifiers
+will be unique or do not care about them.
+
+Thanks to Bruno Boal for refining how the prefix argument is
+processed.  The patch was sent via a private channel.  The change is
+small and thus does not require copyright assignment to the Free
+Software Foundation.
+
+** Menu entries help users discover Denote
+:PROPERTIES:
+:CUSTOM_ID: h:651e5561-f9ce-41f6-bad3-d54ce2dcff04
+:END:
+
+Users of ~menu-bar-mode~ and/or ~context-menu-mode~ will now find a
+submenu with points of entry to Denote.  Refer to the publication I
+made on my website, as it includes a picture:
+<https://protesilaos.com/codelog/2023-03-31-emacs-denote-menu/>.  I
+will save the thousand words for the following sections. 🙃
+
+There is a known issue where the ~menu-bar-mode~ entry is positioned
+before the =File= submenu.  Apparently, there exists an inelegant way
+to place the menu elsewhere, but I am not willing to maintain hacks
+for missing functionality.  If someone knows a clear way to put the
+submenu elsewhere, please contact me: I want it to be after =Tools=.
+
+Thanks to Kai von Fintel and Noboru Ota (nobiot) for discussing the
+placement of the submenu:
+<https://lists.sr.ht/~protesilaos/denote/%3C2B60992C-0FC9-42CC-B669-69A544450FEF%40mit.edu%3E>.
+
+** "Link" commands have simpler names
+:PROPERTIES:
+:CUSTOM_ID: h:acf95a79-3c45-423d-a88f-d6eed7fa5387
+:END:
+
+Originally, Denote was organised as a collection of several files,
+each of which had its own prefix like =denote-dired.el=, and
+=denote-link.el=.  This arrangement was deemed surplus to requirements
+and all core code was consolidated in =denote.el=.  An artefact of
+that design was the presence of symbols that retained their admittedly
+awkward names, like the command ~denote-link-backlinks~ or
+~denote-link-add-missing-links~.
+
+All such commands are deprecated.  They are replaced with more
+discoverable names.  The deprecation is done in such a way that the
+old names are aliases for the new ones, but the user is warned not to
+rely on them.
+
+The new names in detail:
+
+| Old name 🤨                         | New name 🤩                                                   |
+|-------------------------------------+---------------------------------------------------------------|
+| ~denote-link-add-links~             | ~denote-add-links~                                            |
+| ~denote-link-add-missing-links~     | ~denote-add-missing-links~                                    |
+| ~denote-link-backlinks~             | ~denote-backlinks~                                            |
+| ~denote-link-find-file~             | ~denote-find-link~                                            |
+| ~denote-link-insert-link~           | ~denote-insert-link~ (alias for ~denote-link~)                |
+| ~denote-link-show-backlinks-buffer~ | ~denote-show-backlinks-buffer~ (alias for ~denote-backlinks~) |
+
+** Denote buffers can have shorter names
+:PROPERTIES:
+:CUSTOM_ID: h:98f6b10a-ea29-49d1-8d3f-e2f0409f4c8f
+:END:
+
+The Denote file-naming scheme is designed to be a low-tech way of
+embedding information in files, making them easier to find.  A
+downside is that the names are longer than =blah.txt= and so the
+default Emacs behaviour is to derive a buffer name from the file name.
+
+The new optional =denote-rename-buffer.el= provides a minor mode to
+automatically rename the buffer of an existing file, such that it
+reflects the file's =TITLE= field.  Users must enable
+~denote-rename-buffer-mode~.
+
+The renaming procedure is controlled by the user option
+~denote-rename-buffer-function~.  By default, it provides the means to
+rename using (i) the title, (ii) the identifier, or (iii) a custom
+function that returns a string.  Experienced users can refer to
+~denote-rename-buffer-with-title~ to draw inspiration on the design of
+such a function.
+
+Thanks to Morgan Davidson for asking a question that inspired me to
+implement this feature.  The discussion took place in issue 151 on the
+GitHub mirror <https://github.com/protesilaos/denote/issues/151>.
+
+** Silos work as directory trees
+:PROPERTIES:
+:CUSTOM_ID: h:113820c4-7a6f-4126-9a44-92bfa59744e2
+:END:
+
+Denote provides a feature to isolate files in to their own silos, each
+of which functions as its own ~denote-directory~ variable.  The
+technicalities are explained in the manual.  Silos have proven to be a
+valuable aspect of file management and I have thus expanded their
+scope to work as fully fledged directory trees.  This means that we no
+longer assume a silo to be a flat directory listing, but instead
+recognise any subdirectories inside of it.
+
+Thanks to relict007, Hilde Rhyne, Mirko Hernández, Noboru Ota
+(nobiot), Alan Schmitt, hapst3r, and Hilde Rhyne for their
+participation in the relevant discussions:
+  
+- <https://lists.sr.ht/~protesilaos/denote/%3C87fsb72nge.fsf%40protesilaos.com%3E>
+- <https://lists.sr.ht/~protesilaos/denote/%3C80CBB671-D812-4EA8-8C80-85F9F4144051%40disroot.org%3E>
+- <https://lists.sr.ht/~protesilaos/denote/%3C87pma6t59i.fsf%40kotlak.com%3E>
+- <https://github.com/protesilaos/denote/issues/129> (GitHub mirror)
+- <https://lists.sr.ht/~protesilaos/denote/%3CB124A5AF-9968-4F7E-9F4B-2BC763E0BFCF@disroot.org%3E#%3Cm0sff0nnhb.fsf@disroot.org%3E>.
+
+** Keywords do not accept multiple words by default
+:PROPERTIES:
+:CUSTOM_ID: h:08f23806-9570-4031-86e4-810b3e93be81
+:END:
+
+The idea is to have short keywords and then use more than one, if
+necessary.  We do not want to encourage the habit of long keywords
+that become overly specific, while we want to avoid the use of
+dashes as delimited in the file name's =KEYWORDS= field.
+
+Technically, this changes the default value of the user option
+~denote-allow-multi-word-keywords~.  Users who preferred the old
+behaviour can simply toggle it on.
+
+** Pass arguments to Org capture
+:PROPERTIES:
+:CUSTOM_ID: h:58ff6dd3-693a-4437-9217-8e876d92c975
+:END:
+
+Denote is not an extension of Org mode, though it can integrate with
+~org-capture~.  I now make it possible to design a capture template
+that uses specific prompts.  Consult the section in the manual titled
+"Create note with specific prompts using Org capture".
+
+Thanks to Aditya Yadav for asking about this in issue 132 on the
+GitHub mirror: <https://github.com/protesilaos/denote/issues/132>.
+
+** Change an existing note's file type
+:PROPERTIES:
+:CUSTOM_ID: h:e1e874e3-d8ad-4685-aa62-59ad07078db2
+:END:
+
+The command ~denote-change-file-type~ changes the file type of an
+existing note.  The available options are those among
+~denote-file-type~.  Thanks to Jean-Philippe Gagné Guay for the
+contribution, which was done in pull request 137 on the GitHub mirror:
+<https://github.com/protesilaos/denote/pull/137>.
+
+** Denote dynamic blocks can now parse ~rx~ notation
+:PROPERTIES:
+:CUSTOM_ID: h:fe595ee7-8ba6-4ca3-aa66-35aa4e5ca0f5
+:END:
+
+Denote can leverage the Org feature of "dynamic blocks" to produce
+lists of links/backlinks.  This is especially useful for metanotes
+(read the Denote manual---I document everything for a reason).
+
+Before, regular expressions were implemented only as strings while now
+they can also be written using the ~rx~ notation.  Thanks to Mirko
+Hernandez for proposing this feature and discussing it with me in
+issue 122 on the GitHub mirror:
+<https://github.com/protesilaos/denote/issues/122>.
+
+Thanks to Elias Storms, the author of =denote-org-dblock.el=, for
+iterating on this functionality.  This was done in pull request 130 on
+the GitHub mirror: <https://github.com/protesilaos/denote/pull/130>.
+
+** Made links to non-note files works as intended
+:PROPERTIES:
+:CUSTOM_ID: h:431a8952-0d71-4ba6-b6ae-85e5f7d520b9
+:END:
+
+The function ~denote-get-path-by-id~ is refactored to accept any file
+with an identifier.  This always was its intended purpose.  The user
+was always able to create =denote:= Org link types to, for example,
+=jpg= files but ~denote-get-path-by-id~ was refusing to resolve the
+otherwise valid path.  Thanks to user relict007 for reporting the
+problem and discussing it with me in issue 135 on the GitHub mirror:
+<https://github.com/protesilaos/denote/issues/135>.
+
+The change was not trivial.  It was followed up by a patch from Noboru
+Ota (nobiot) which elaborated on the conditionality.  Quoting from
+commit =9ce9a24=:
+  
+#+begin_quote
+fix(denote-get-path-by-id): #135
+
+Reference: https://github.com/protesilaos/denote/issues/135
+
+This patch change function 'denote-get-path-by-id' to allow for the following:
+
+- A single ID points to multiple files with different extensions
+- Denote needs to find a single file out of the multiple files
+- This is not necessarily a user error (export an Org file to an HTML)
+- Denote should let user decide their "primary" file extension
+
+The case the patch is intended to fix goes something like this:
+
+- You have 20230216__mynotes--tag.org.
+- You export it to 20230216__mynotes--tag.html.
+- Both files are in denote-directory
+- This means you have two files with the same ID with different
+  extensions denote-link-find-file, denote-link-find-backlink, and xref
+  integration might find the html file INSTEAD OF the .org file
+
+This is because html is earlier in the alphabetical order than
+org. Because the function uses seq-find, it will find the .html file
+first and returns it.
+#+end_quote
+
+** The ~denote-rename-file-using-front-matter~ works with empty keywords
+:PROPERTIES:
+:CUSTOM_ID: h:b00f228d-7f84-4d84-8d5f-ac90ea6b1065
+:END:
+
+Keywords are an optional field in the Denote file-naming scheme.
+However, an earlier version of the command mentioned in this heading
+was considering them mandatory and would refuse to proceed if the
+keywords were nil.  Thanks to Eduardo Grajeda for fixing this:
+<https://lists.sr.ht/~protesilaos/denote/patches/39896>.
+
+The change is within the ~15 line limit and does not require copyright
+assignment to the Free Software Foundation.
+
+** The ~denote-title-prompt~ has its own history
+:PROPERTIES:
+:CUSTOM_ID: h:91f370f4-9fd1-461b-8ba4-fd9ba2d9c7a8
+:END:
+
+Denote implements minibuffer histories for all its relevant functions.
+This makes it easier for users to retrieve their previous inputs and
+to not get irrelevant ones.
+
+Before, the ~denote-title-prompt~ was not using its own history but
+was instead relying on another one that was intended only for file
+paths, thus mixing unrelated inputs.
+
+Thanks to Jonathan Sahar for bringing this matter to my attention.
+This was done in issue 144 on the GitHub mirror:
+<https://github.com/protesilaos/denote/issues/144>.
+
+** For developers or advanced users
+:PROPERTIES:
+:CUSTOM_ID: h:dcc52671-2127-47e0-9167-003f40ca3a54
+:END:
+
+*** Made it possible to add predicates for recursive file listing
+:PROPERTIES:
+:CUSTOM_ID: h:62546ec1-6ec8-41c7-9a18-10a531b534ce
+:END:
+
+The helper function ~denote--directory-all-files-recursively~ accepts
+predicates to help speed up its work.
+
+Thanks to Wade Mealing for reporting the issue about the performance
+of the built-in function ~directory-files-recursively~ in large,
+nested directories.  And thanks to Graham Marlow for the patch, which
+was prepared as part of an extended discussion with me:
+
+- <https://lists.sr.ht/~protesilaos/denote/patches/40370>
+- <https://lists.sr.ht/~protesilaos/denote/%3C20230414000311.1981-1-graham%40mgmarlow.com%3E#%3C76ed9fe2-d597-f7b9-5e59-717aeb77c3c3@mgmarlow.com%3E>
+- <https://lists.sr.ht/~protesilaos/denote/patches/40384>
+- <https://lists.sr.ht/~protesilaos/denote/%3C87edonhvy0.fsf%40protesilaos.com%3E>
+- <https://lists.sr.ht/~protesilaos/denote/%3C76ed9fe2-d597-f7b9-5e59-717aeb77c3c3%40mgmarlow.com%3E>
+- <https://lists.sr.ht/~protesilaos/denote/%3C87zg75q4er.fsf%40protesilaos.com%3E>
+- <https://lists.sr.ht/~protesilaos/denote/%3CCAO4UgPQtxhhqW0tB7eZnVh4nF9vLvnVGx+5oB_78_dg32URSLA%40mail.gmail.com%3E>
+
+*** New public symbols
+:PROPERTIES:
+:CUSTOM_ID: h:ed723274-a78e-4cfd-9655-c3bfe0fb1e68
+:END:
+
+The following are now public symbols that we commit to support and
+document henceforth:
+
++ Function ~denote-file-type-extensions~ :: Return all file type
+  extensions in ~denote-file-types~.
+
++ Variable ~denote-encryption-file-extensions~ :: List of strings
+  specifying file extensions for encryption.
+
++ Function ~denote-file-type-extensions-with-encryption~ :: Derive
+  ~denote-file-type-extensions~ plus ~denote-encryption-file-extensions~.
+
++ Function ~denote-link-return-links~ :: Return list of links in
+  current or optional =FILE=.  Also see ~denote-link-return-backlinks~.
+
++ Function ~denote-link-return-backlinks~ :: Return list of links in
+  current or optional =FILE=.  Also see ~denote-link-return-links~.
+
++ Function ~denote-rewrite-front-matter~ :: Rewrite front matter of
+  note after ~denote-rename-file~ (or related) The =FILE=, =TITLE=,
+  =KEYWORDS=, and =FILE-TYPE= arguments are given by the renaming
+  command and are used to construct new front matter values if
+  appropriate.
+
++ Function ~denote-rewrite-keywords~ :: Rewrite =KEYWORDS= in =FILE=
+  outright according to =FILE-TYPE=.  Do the same as
+  ~denote-rewrite-front-matter~ for keywords, but do not ask for
+  confirmation.  This is for use in ~denote-keywords-add~,
+  ~denote-keywords-remove~, ~denote-dired-rename-marked-files~, or
+  related.
+
+I am publicising the ~denote-link-return-links~ and its counterpart in
+response to the mailing list thread started by relict007:
+<https://lists.sr.ht/~protesilaos/denote/%3C87a5ygk6yi.fsf@kotlak.com%3E>.
+relict007 is the developer of the ~denote-cache~ package (in
+progress): <https://git.sr.ht/~relict007/denote-cache>.
+
+Similarly, the ~denote-rewrite-keywords~ is made public upon the
+request of Alan Schmitt:
+<https://lists.sr.ht/~protesilaos/denote/%3Cm2ttzgn2wu.fsf%40m4x.org%3E>.
+
+** Miscellaneous
+:PROPERTIES:
+:CUSTOM_ID: h:918087e6-8cd5-4d4f-a11a-b465dcbd9fe3
+:END:
+
+- Revised ~denote-link-return-{links,backlinks}~ to not produce a
+  ~user-error~.  The errors are reserved for the interactive
+  functions. The others are for developers. Thanks to Elias Storms for
+  bringing this matter to my attention:
+  <https://github.com/protesilaos/denote/commit/694c1517be73949edbc3993c105c764da8e2571f#commitcomment-112677876>.
+
+- Refrained from trying to find forward links in non-text-files.  If a
+  file extension is not in ~denote-file-types~, we have no way of
+  parsing or finding outgoing links in it. This change checks for the
+  file extension early on in 'when-let*' block and avoids opening the
+  file which is a relatively costly operation (and would fail finding
+  links anyway).  Thanks to relict007 for the patch.  This was done on
+  the mailing list:
+  <https://lists.sr.ht/~protesilaos/denote/%3C87r0riffdx.fsf%40kotlak.com%3E>
+  The change is small and thus does not require copyright assignment
+  to the Free Software Foundation.
+
+- Explained how to troubleshoot Denote.  Refer to the section in the
+  manual titled "Troubleshoot Denote in a pristine environment."
+  While this is about Denote, the skills apply to all Emacs packages.
+
+- Ensured backlinks get correct ~denote-directory~ path.  The
+  backlinks buffer will now get the correct path when it is generated
+  inside a silo.  This is related to issue 129 reported by hapst3r on
+  the GitHub mirror: <https://github.com/protesilaos/denote/issues/129>.
+  The change is necessary because =.dir-locals.el= do not work for
+  buffers, so we must get the value from the file that calls
+  ~denote-link-backlinks~.
+
+- Added missing underscore from examples in exporting section.  Thanks
+  to Peter Prevos for bringing this matter to my attention:
+  <https://lists.sr.ht/~protesilaos/denote/%3C87fs8b85tq.fsf%40prevos.net%3E#%3C87lehiuxfo.fsf@protesilaos.com%3E>.
+
+- Made the command ~denote-open-or-create~ work with an empty
+  ~denote-directory~.  The ~denote-file-prompt~ would throw an error
+  before.  The correct behaviour is to proceed to the "Create" phase
+  if the ~denote-directory~ is empty.  Thanks to user drcxd for
+  reporting the bug in issue 131 on the GitHub mirror and for testing
+  my sample code: <https://github.com/protesilaos/denote/issues/131>.
+
+- Documented how to use tree-based file prompt on demand.  This is my
+  solution to a request made by Mirko Hernandez on the possible use of
+  the old Denote file prompt.  It is better not to introduce a user
+  option for this case, nor to keep multiple variants of the
+  ~denote-file-prompt~ in denote.el, as we want to keep things simple.
+  Mirko's feedback was provided in issue 121 on the GitHub mirror:
+  <https://github.com/protesilaos/denote/issues/121>.
+
+- Added the variable ~denote-user-enforced-denote-directory~.  This is
+  intended for users who write custom code to extend Denote.  The
+  value of this variable should be ~let~ bound around calls to the
+  function ~denote-directory~, thus overriding its return value.  This
+  was discussed on the mailing list and then introduced by Vedang
+  Manerikar in commit =977c757=, with further changes by me in
+  =20ddc97=: <https://lists.sr.ht/~protesilaos/denote/patches/41776>.
+  Vedang has assigned copyright to the Free Software Foundation.
+
+- Fixed ~my-denote-org-extract-subtree~ section of the documentation.
+  This is part of some sample code that is not part of =denote.el=,
+  but we provide as a convenience/inspiration for interested parties.
+
+  The provided function did not work correctly.
+
+  1. Tags are extracted before deleting the region from the source file.
+  2. The function ~org-end-of-subtree~ is called to calculate the
+     point we should delete up to.  The previously used function
+     ~org-entry-end-position~ ends at the first sub-heading under the
+     tree, which is not what we want.  Instead, we want to cut the
+     whole subtree.
+  3. The date information available in the subtree is retained.  We
+     look for three common places for this information: the =CREATED=
+     or =DATE= properties in the =PROPERTIES= drawer, and the =CLOSED=
+     cookie at the element level itself.
+
+  Thanks to Vedang Manerikar for the contribution:
+  <https://lists.sr.ht/~protesilaos/denote/%3CCABzEscbPx24LCUCc7JsMmQtVGwhou5fUH_5h+%3Dt%3Dqi4396NqNQ%40mail.gmail.com%3E>
+
+- Removed the dependency on the built-in ~xdg~ library and updated the
+  default value of the user option ~denote-directory~.  The reason is
+  that XDG is a Linux standard that does not work on other operating
+  systems, according to private feedback I received.
+
+- Fixed a regression for =M-p= (~previous-history-element~) in "do or
+  create" commands.  Read the doc string of the commands
+  ~denote-open-or-create~ or ~denote-link-or-create~ for how this is
+  supposed to work.  In short:
+  
+  - Invoke the "do or create" command.
+  - Type something that does not match a file.
+  - In the following title prompt, hit =M-p= to bring back the last input.
+  
+  I realised there was a regression when I read issue 152 on the
+  GitHub mirror, which was created by user "ustcpxy":
+  <https://github.com/protesilaos/denote/issues/152>.  The issue is
+  about skipping the file title prompt.
+
+- Simplified the internal ~denote--buffer-file-names~.  Thanks to Adam
+  Růžička for noting that my change was not compatible with older
+  Emacs versions, and for preparing the change.  This was discussed in
+  pull request 158 on the GitHub mirror, with my suggestion to not use
+  ~seq-filter~ as it affected the return value:
+  <https://github.com/protesilaos/denote/pull/158>. The change is
+  below the 15 line limit, meaning that Adam does have to assign
+  copyright to the Free Software Foundation.
+
+- Documented custom code in the manual on how to interactively select
+  a silo.  I am providing this in response to a request from GitHub
+  user rbenit68.  The discussion took place in issue 127 on the GitHub
+  mirror, with the participation of Mirko Hernandez:
+  <https://github.com/protesilaos/denote/issues/127>. The custom code
+  I provide is the expanded version of an idea put forth by Mirko, to
+  whom I am thankful.
+
+- Fixed an outdated reference in the ~denote-file-types~ doc string.
+  Thanks to user doolio for spotting the error and reporting it in
+  issue 139 on the GitHub mirror:
+  <https://github.com/protesilaos/denote/issues/139>.
+
+- Cited in the manual's section "Publications about Denote" an article
+  by Mohamed Suliman titled /Managing a bibliography of BiBTeX entries
+  with Denote/ (2022-12-20):
+  <https://www.scss.tcd.ie/~sulimanm/posts/denote-bibliography.html>.
+  If you have published something related to Denote, please let me
+  know and I will add to the list.
+
+- Cited the essay by Summer Emacs titled /An explanation of how I use
+  Emacs/ (2023-05-04):
+  <https://github.com/summeremacs/howiuseemacs/blob/main/full-explanation-of-how-i-use-emacs.org>
+
+- Cited the video series by Stefan Thesing titled /Denote as a
+  Zettelkasten/: <https://www.thesing-online.de/blog/denote-as-a-zettelkasten/>.
+
+- Added link to Karl Voit's work in the manual's section "Alternative
+  implementations and further reading."  Thanks to Norwid Behrnd for
+  the contribution in pull request 123 on the GitHub mirror:
+  <https://github.com/protesilaos/denote/pull/123>.
+
+- Fixed the broken link to jao's blog.  Thanks to Tomasz Hołubowicz
+  for the contribution, which was done in pull request 145 on the
+  GitHub mirror: <https://github.com/protesilaos/denote/pull/145>.
+
+- Authored lots of other ancillary changes/features to the code base
+  or the manual (yes, this change log is how I "cut the long store
+  short").
+
+* Version 1.2.0 on 2022-12-12
+:PROPERTIES:
+:CUSTOM_ID: h:92478a05-4a69-413c-8d95-1dacbcf6af2c
+:END:
+
+** Denote now requires Emacs version 28.1 or higher
+:PROPERTIES:
+:CUSTOM_ID: h:bc0e173a-3b9f-427c-9fb0-d435a5ef127e
+:END:
+
+With the help of Noboru Ota (nobiot), we realised that Denote was
+broken on Emacs 27 for quite a while.  The fact that we received no
+feedback about it suggests that this change is the best course of
+action going forward.  Discussion:
+<https://lists.sr.ht/~protesilaos/denote/%3C86r0yvzm12.fsf%40nobiot.com%3E#%3C86sfja78ik.fsf@nobiot.com%3E>
+
+Emacs 27 lacks certain Xref facilities that we need for the
+backlinking facility.  It was holding us back for no good reason,
+while also adding to the maintenance burden.
+
+If you are using Denote on Emacs 27 and things are working for you,
+there is no need to update the package.  Do it when you also upgrade
+Emacs to a newer version.
+
+** Display context in backlinks' buffer
+:PROPERTIES:
+:CUSTOM_ID: h:dafbdbae-36f1-487a-94c8-2762568a766e
+:END:
+
+By default, the generic backlinks' buffer, which can be displayed with
+the command ~denote-link-backlinks~ (alias ~denote-link-show-backlinks-buffer~),
+only shows the file names of the linked notes.
+
+We have made it possible to produce a more informative view by showing
+the context of the link and also listing all links per file.  This is
+done by setting the user option ~denote-backlinks-show-context~ to a
+non-nil value.
+
+To illustrate the difference, this is the default backlinks' buffer:
+
+#+begin_example
+Backlinks to "On being honest" (20220614T130812)
+------------------------------------------------
+
+20220614T145606--let-this-glance-become-a-stare__journal.txt
+20220616T182958--feeling-butterflies-in-your-stomach__journal.txt
+#+end_example
+
+And this is the one with ~denote-backlinks-show-context~ enabled:
+
+#+begin_example
+Backlinks to "On being honest" (20220614T130812)
+------------------------------------------------
+
+20220614T145606--let-this-glance-become-a-stare__journal.txt
+37: growing into it: [[denote:20220614T130812][On being honest]].
+64: As I said in [[denote:20220614T130812][On being honest]] I have never
+20220616T182958--feeling-butterflies-in-your-stomach__journal.txt
+62: indifference.  In [[denote:20220614T130812][On being honest]] I alluded
+#+end_example
+
+Granted, here we show plain text though in Emacs the results have the
+appropriate colours of the active theme and are easier to read.
+
+Thanks to Noboru Ota (nobiot) for implementing this feature.  We
+discussed it at length on the mailing list:
+<https://lists.sr.ht/~protesilaos/denote/%3C86r0yvzm12.fsf%40nobiot.com%3E>.
+
+Noboru has assigned copyright to the Free Software Foundation.
+
+** Dynamic Org blocks for lists of Denote links
+:PROPERTIES:
+:CUSTOM_ID: h:f7904a57-22c0-446f-b7e3-7a736332002c
+:END:
+
+Denote now includes the ~denote-org-dblock~ library.  Activate it
+thus:
+
+#+begin_src emacs-lisp
+;; Register Denote's Org dynamic blocks
+(require 'denote-org-dblock)
+#+end_src
+
+A dynamic block gets its contents by evaluating a given function,
+depending on the type of block.  The type of block and its parameters
+are stated in the opening =#+BEGIN= line of the block.  Typing =C-c
+C-c= with point on that line runs the function, with the given
+arguments, and populates the block's contents accordingly.
+
+What Denote has is ways to write blocks that produce a list of links
+matching a given regular expression while conforming with some other
+parameters.  The manual explains how to use this powerful feature
+(which is necessarily specific to the Org file type):
+<https://protesilaos.com/emacs/denote#h:8b542c50-dcc9-4bca-8037-a36599b22779>.
+
+Thanks to Elias Storms for authoring ~denote-org-dblock~ and for
+discussing this issue at length with me on the mailing list:
+<https://lists.sr.ht/~protesilaos/denote/%3Cm2sfisexx7.fsf%40MBA21.fritz.box%3E>.
+
+Elias has assigned copyright to the Free Software Foundation.
+
+** Integration with the built-in project.el and xref.el libraries
+:PROPERTIES:
+:CUSTOM_ID: h:e8a7d08c-cdf0-4207-92c1-391415b8371f
+:END:
+
+Denote was already using Xref internally but has now gained more
+capabilities which help it find files more effectively.  With the help
+of Emacs' standard project library, all file-related prompts (e.g. to
+add a link) search all items in the ~denote-directory~ regardless of
+whether the user is in a subdirectory or not.
+
+All Denote commands benefit from this refactoring.  One such request
+to "Make ~denote-open-or-create~ work better across subfolders" was
+made in issue 114 on the GitHub mirror:
+<https://github.com/protesilaos/denote/issues/114>.
+
+Thanks to Noboru Ota (nobiot) for introducing this feature together
+with a new system of "modules" for incorporating additional built-in
+functionality:
+
+- <https://lists.sr.ht/~protesilaos/denote/%3C86a64ooxyi.fsf%40nobiot.com%3E>
+- <https://lists.sr.ht/~protesilaos/denote/%3C86k03f4iq6.fsf%40nobiot.com%3E>
+
+I will not document the new user option ~denote-modules~ right now as
+my ongoing job search prevented me from exploring the full potential
+of this feature.  I promise to do it for the next version of Denote
+and update the manual accordingly.  Nevertheless, the doc string of
+~denote-modules~ already provides all one needs to get started.
+
+** Re-use last input in "do or create" commands
+:PROPERTIES:
+:CUSTOM_ID: h:5a003d44-7ad0-4c92-b908-ec7cf016b2dd
+:END:
+
+The commands ~denote-open-or-create~, ~denote-link-or-create~ first
+prompt for an existing note.  If they find it, they act on it,
+otherwise they prompt for the creation of a new note to operate on.
+
+At the first prompt, it is common to use regular expressions and
+out-of-order pattern matching (such as with the ~orderless~ package),
+so the input can be something like =_test ^2022 some title=, which we
+obviously don't want to automatically reuse as the new note's actual
+title.
+
+To this end, and to accommodate all workflows, we leverage Emacs'
+minibuffer history to make the last input accessible with =M-p= at the
+minibuffer prompt (=M-x previous-history-element=).  The text is
+available for further editing before it is submitted as the new note's
+title.  Simple, effective, and flexible!
+
+Thanks to Guo Yong for starting the discussion that led me to this
+improvement:
+<https://lists.sr.ht/~protesilaos/denote/%3CNF6pFBq--3-9%40tutanota.com%3E>.
+
+** Add support for any file type
+:PROPERTIES:
+:CUSTOM_ID: h:e73a4e76-6c00-4691-8893-8f885c26f306
+:END:
+
+Denote provides the user option ~denote-file-type~ which specifies the
+file type to use for new notes.  Options include Org mode (the
+default), Markdown+YAML, Markdown+TOML, and plain text.  Furthermore,
+there exists the convenience command ~denote-type~ (alias
+~denote-create-note-using-type~) which prompts for a file type to use
+when creating a new note (I normally write in plain text, but
+sometimes switch to Org or Markdown).
+
+The variable ~denote-file-types~ (which is NOT a user option)
+specifies all the parameters of what a "file type" means, such as how
+to format its front matter, what style of date+time to use, which file
+type extension to write, how to rename the file, what style of link to
+apply, and so on.  Advanced users can now edit this variable to either
+register new file types or redefine the behaviour of existing ones.
+Read this comprehensive guide on how to do it:
+<https://protesilaos.com/codelog/2022-10-30-demo-denote-custom-file-type/>.
+
+I repeat: this is for advanced users or, anyhow, for those who are
+prepared to maintain some custom code in their setup.  The guide is
+accessible though and I am always willing to help anyone in need of
+assistance.
+
+A relevant request for such a feature can be found in issue 86 on the
+GitHub mirror: <https://github.com/protesilaos/denote/issues/86>.
+
+The ~denote-file-types~ were introduced by Jean-Philippe Gagné Guay in
+pull request 89 at the GitHub mirror and were part of Denote version
+0.6.0: <https://github.com/protesilaos/denote/pull/89>.  I have made
+lots of changes since then to make all parts of Denote work with it
+and to parameterise its various facets.
+
+** Exclude certain directories from all operations
+:PROPERTIES:
+:CUSTOM_ID: h:04f42aab-d8fe-4c4a-b865-3bb0655e2631
+:END:
+
+The user option ~denote-excluded-directories-regexp~ instructs all
+Denote functions that read or check file/directory names to omit
+directories that match the given regular expression.  The regexp needs
+to match only the name of the directory, not its full path.
+
+Affected operations include file prompts and functions that return the
+available files in the ~denote-directory~.  File prompts are used by
+several commands, such as ~denote-link~ and ~denote-subdirectory~.
+Functions that check for files include ~denote-directory-files~ and
+~denote-directory-subdirectories~.
+
+Thanks to Graham Marlow for the contribution which was done in pull
+request 112 on the GitHub mirror:
+<https://github.com/protesilaos/denote/pull/112>.
+
+The original contribution, with the subsequent tweaks I made to it, is
+within the eligible line count and thus does not require copyright
+assignment to the Free Software Foundation.
+
+** Exclude certain keywords from being inferred
+:PROPERTIES:
+:CUSTOM_ID: h:226ba85e-1f5e-45f5-956a-f5e8a95c397e
+:END:
+
+The user option ~denote-excluded-keywords-regexp~ omits keywords that
+match a regular expression from the list of inferred keywords.
+
+Keywords are inferred from file names and provided at relevant prompts
+as completion candidates when the user option ~denote-infer-keywords~
+is non-nil.
+
+Thanks to Stefan Thesing for proposing this idea in issue 115 on the
+GitHub mirror: <https://github.com/protesilaos/denote/issues/115>.
+
+[ Other people participate in that thread and there may be something
+  more coming out of it. ]
+
+** Use the ~citar-denote~ package for bibliography notes
+:PROPERTIES:
+:CUSTOM_ID: h:ff16633f-5fb8-4935-9e2f-044ec998d3f7
+:END:
+
+Peter Prevos has produced the ~citar-denote~ package which makes it
+possible to write notes on BibTeX entries with the help of the ~citar~
+package.  These notes have the citation's unique key associated with
+them in the file's front matter.  They also get a configurable keyword
+in their file name, making it easy to find them in Dired and/or
+retrieve them with the various Denote methods.
+
+With ~citar-denote~, the user leverages standard minibuffer completion
+mechanisms (e.g. with the help of the ~vertico~ and ~embark~ packages)
+to manage bibliographic notes and access those notes with ease.  The
+package's documentation covers the details: <https://github.com/pprevos/citar-denote/>.
+
+Thanks to Peter Prevos for developing this package and for mentioning
+it on the Denote mailing list:
+<https://lists.sr.ht/~protesilaos/denote/%3C877cz0e96r.fsf%40prevos.net%3E>.
+
+** New functions and variables for developers
+:PROPERTIES:
+:CUSTOM_ID: h:5cc2076d-d4d2-45be-b28e-9ec67eca82b4
+:END:
+
+Developers or users who maintain custom code now have access to:
+
++ Function ~denote-keywords-sort~
++ Function ~denote-keywords-prompt~
+
+Plus all the following which are related to the aforementioned ~denote-file-types~:
+
++ Variable ~denote-org-link-format~
++ Variable ~denote-md-link-format~
++ Variable ~denote-id-only-link-format~
++ Variable ~denote-org-link-in-context-regexp~
++ Variable ~denote-md-link-in-context-regexp~
++ Variable ~denote-id-only-link-in-context-regexp~
++ Function ~denote-date-org-timestamp~
++ Function ~denote-date-rfc3339~
++ Function ~denote-date-iso-8601~
+
+Again, users can implement support for ANY FILE TYPE and use it to
+write notes in, either as their default choice or on-demand.  If
+anything, this highlights the flexibility of Denote.
+
+** Miscellaneous
+:PROPERTIES:
+:CUSTOM_ID: h:acbb0cf7-ad17-495e-85d2-821cbbfc3158
+:END:
+
++ Added the ~denote-keywords-sort~ function.  The intent is to
+  abstract the task of sorting the keywords.  Before, it was handled
+  by the ~denote-keywords-prompt~, which meant that keywords were not
+  sorted when the ~denote~ function was called from Lisp.  Thanks to
+  Florian for bringing this matter to my attention, providing relevant
+  feedback, and fixing an omission of mine in ~denote-rename-file~:
+  <https://lists.sr.ht/~protesilaos/denote/%3C166689879712.8.6808878344988686135.71824507%40aboulafia.org%3E>.
+
++ Expanded the manual's entry on directory "silos" to include more
+  code examples.  Thanks to Viktor Haag for asking a question on the
+  mailing list that inspired me to produce this entry:
+  <https://lists.sr.ht/~protesilaos/denote/%3CCANnkwC6NLd0VneUEqFrjh7TCUBLBgEtLCcPwM37JDvJXJCShVQ%40mail.gmail.com%3E>.
+
++ Included a section in the manual with a non-exhaustive list of
+  references to publications about Denote.  As of this writing, it
+  includes entries from David Wilson (SystemCrafters), Jack Baty,
+  Jeremy Friesen, and Peter Prevos.  If you have an article about
+  Denote, please contact me about it directly or on the Denote mailing
+  list and I will add it to the manual.
+
++ Tweaked how Org's HTML export produces links in order to avoid
+  broken subdirectory paths.  Thanks to Thibaut Benjamin for the
+  contribution, which was done in pull request 116 on the GitHub
+  mirror: <https://github.com/protesilaos/denote/pull/116>.
+
+  The change concerns a single line and thus Thibaut requires no
+  copyright assignment to the Free Software Foundation.
+
++ Expanded the manual where necessary.
+
+* Version 1.1.0 on 2022-10-20
+:PROPERTIES:
+:CUSTOM_ID: h:8e0f536a-ab3b-4cab-82f7-529bc0e40dbd
+:END:
+
+** New commands or refinements to common use-cases
+:PROPERTIES:
+:CUSTOM_ID: h:5665e7ec-4f3a-4de3-8cb0-63d25a0db8c1
+:END:
+
++ The ~denote-link-add-missing-links~ is a companion to what we
+  already provide to produce a list of links to Denote files matching
+  a regular expression (the ~denote-link-add-links~).  This new
+  command adds links that are not already present in the current file.
+  So if you have a metanote that references, say, your journal entries
+  but have not updated it in a month, you can revisit the metanote,
+  invoke ~denote-link-add-missing-links~, and then type the search
+  terms (e.g. =_journal=) to include what remains.
+
+  Thanks to Elias Storms for the initial contribution, which was done
+  in pull request 108 on the GitHub mirror:
+  <https://github.com/protesilaos/denote/pull/108>.
+
+  Elias has assigned copyright to the Free Software Foundation.  It is
+  required for changes that exceed 15 lines in total.
+
++ The ~denote-link-find-backlink~ provides a minibuffer interface that
+  shows all backlinks to the current note.  It complements the
+  existing ~denote-link-backlinks~ command (which also has the alias
+  ~denote-link-show-backlinks-buffer~).  Each command has its own
+  niche: the minibuffer lets the user leverage powerful pattern
+  matching styles, such as those provided by the =orderless= package,
+  while the bespoke buffer provides an easy overview of what links to
+  the current note.
+
+  Thanks to Elias Storms for the original patch:
+  <https://lists.sr.ht/~protesilaos/denote/%3Cm2fsg6o2t6.fsf%40MBA21.fritz.box%3E#%3Cm2pmfam7yi.fsf@MBA21.fritz.box%3E>.
+
++ The ~denote-keywords-add~ and ~denote-keywords-remove~ are two
+  commands that interactively operate on the current note's front
+  matter to add or remove keywords.  They use the familiar keywords'
+  prompt which means, among others, that they can read more than one
+  keyword at a time.  To specify multiple keywords, separate each
+  input with a comma (or whatever the value of ~crm-separator~ is,
+  which should be a comma unless something out-of-the-ordinary is in
+  force).
+
+  Thanks to Elias Storms for the original patch, which was done as
+  part of a discussion on the mailing list and then iterated on:
+  <https://lists.sr.ht/~protesilaos/denote/%3Cm24jwvpbt2.fsf%40MBA21.fritz.box%3E#%3Cm28rlik0tc.fsf@MBA21.fritz.box%3E>.
+
++ The ~denote-link~ command will now recognise an active region and
+  use its text as the description of the inserted link.  The default
+  behaviour is to use the file's title from its front matter or file
+  name.  Thanks to Charanjit Singh for the original contribution,
+  which was done as part of pull request 109 on the GitHub mirror:
+  <https://github.com/protesilaos/denote/pull/109>.  A subsequent
+  tweak was implemented in pull request 110, following a discussion
+  with me: <https://github.com/protesilaos/denote/pull/110>.
+
+  Charanjit's contribution is below the ~15 line threshold and thus
+  does not require copyright assignment to the Free Software
+  Foundation.
+
++ The renaming operations are now aware of the underlying version
+  control system and will use the appropriate command when a VCS is
+  available.  In practice, renaming a file under, say, Git will
+  register it as a "rename" instead of two separate actions of
+  deletion and addition.
+
+  Thanks to Florian for the patch.  It was discussed on the mailing
+  list and then underwent some changes:
+  <https://lists.sr.ht/~protesilaos/denote/%3C166547153518.8.941129310186454444.68125516@aboulafia.org%3E>.
+
++ The ~denote-rename-file-using-front-matter~ no longer fails to carry
+  out its intended task when the front matter has no keywords.  If no
+  keywords are available, this is interpreted as a request to remove
+  the KEYWORDS component of the file name.  This was always
+  technically possible and could be achieved with various permutations
+  of the user option ~denote-prompts~ (as explained in its doc string
+  or the manual).  Denote only needs an identifier in the file name to
+  establish unique links (although I strongly encourage you to stick
+  to the standard file-naming scheme as it is informative, reliable,
+  and can work even if you access your data without Emacs).
+
+** For more advanced use-cases
+:PROPERTIES:
+:CUSTOM_ID: h:505c84dd-2959-4bd4-8af4-78d75592a6d5
+:END:
+
++ The variable ~denote-file-types~ has been tweaked to respond
+  directly to changes in its value done with ~setq~.  Thanks to Noboru
+  Ota for the patch: <https://lists.sr.ht/~protesilaos/denote/%3C86k05gsqsg.fsf%40nobiot.com%3E>.
+
+  Noboru has assigned copyright to the Free Software Foundation.
+
++ The =:front-matter= property of the ~denote-file-types~ now accepts
+  a nil value.  Denote could always work without front matter, but
+  this was not implemented flexibly in the ~denote-file-types~.
+  Thanks to Noboru Ota (nobiot) for pointing this out on the mailing
+  list: <https://lists.sr.ht/~protesilaos/denote/%3C86k05gsqsg.fsf%40nobiot.com%3E>.
+
++ The ~denote-file-prompt~ function now reads an optional
+  =INITIAL-TEXT= argument.  This is a string that prepopulates the
+  minibuffer.  It is useful for custom commands the user may have
+  where, for example, there is a need to automatically filter to
+  entries matching =_journal=.  Thanks to Alan Schmitt for suggesting
+  the idea: <https://lists.sr.ht/~protesilaos/denote/%3C87pmf676n1.fsf@m4x.org%3E>.
+
++ The ~denote-rename-file-using-front-matter~ accepts an optional
+  =AUTO-CONFIRM= argument.  It can either be passed interactively or
+  via Lisp.  The doc string (or the manual) explains the details.
+  Thanks to Elias Storms for the initial patch:
+  <https://lists.sr.ht/~protesilaos/denote/%3Cm2a667aeku.fsf%40gmail.com%3E>.
+
++ The ~denote-prompt-for-date-return-id~ function uses the familiar
+  ~denote-date-prompt~ and returns the appropriate identifier.  It is
+  used internally by some of our function, but we also provide it for
+  anyone who wants to write their own custom code.
+
++ The ~denote-retrieve-or-create-file-identifier~ function reads and
+  option =DATE= argument to its mandatory =FILE= argument.  If =FILE=
+  does not have an identifier and optional =DATE= is non-nil, the
+  function invokes the ~denote-prompt-for-date-return-id~, as
+  mentioned above.
+
++ The ~denote-rename-file~ command accepts an optional =DATE=
+  argument.  It functionally does what is described right above, with
+  the exception that this is for an interactive function (a
+  "command").  Read the detailed doc string or the manual for
+  everything that pertains to this powerful command.
+
+  Thanks to Florian for suggesting the idea on the mailing list:
+  <https://lists.sr.ht/~protesilaos/denote/%3C166521684647.7.5483179875879361874.67576870%40aboulafia.org%3E>.
+
++ The ~denote-directory-text-only-files~ function filters the
+  ~denote-directory-files~ to only return a list of text files.  This
+  leaves out, say, mp3 files.  The function is used internally, though
+  it may also prove useful in custom user code.
+
+** Miscellaneous refinements
+:PROPERTIES:
+:CUSTOM_ID: h:0531047f-ef15-412e-b265-886c55526d57
+:END:
+
++ Implemented a ~revert-buffer-function~ for the backlinks' buffer,
+  which is produced by the command ~denote-link-backlinks~.  This
+  revert function is what the =g= key invokes with the default key
+  bindings (the command is ~revert-buffer~).  It produces the buffer
+  anew, updating the list of backlinks accordingly.
+
++ Documented how to speed up the creation of the backlinks' buffer.
+  As this depends on the built-in =xref= library, the change is done
+  by specifying the value of the user option ~xref-search-program~ in
+  Emacs 28 or higher.  For example:
+
+  #+begin_src emacs-lisp
+  (setq xref-search-program 'ripgrep)
+  #+end_src
+
+  For something more elaborate:
+
+  #+begin_src emacs-lisp
+  ;; Prefer ripgrep, then ugrep, and fall back to regular grep.
+  (setq xref-search-program
+        (cond
+         ((or (executable-find "ripgrep")
+              (executable-find "rg"))
+          'ripgrep)
+         ((executable-find "ugrep")
+          'ugrep)
+         (t
+          'grep)))
+  #+end_src
+
++ Removed some minor duplication of effort in how the buttonisation of
+  links is done (what makes them clickable).
+
++ Made refinements to the definition of functions such as
+  ~denote-link-add-links~.  There should be no noticeable change for
+  users, though this shows we care about code quality.
+
++ With Eshel Yaron, we tried to remove the empty indices for functions
+  and variables from the HTML version of the manual.  These indices
+  are useful in the Info version, which can be accessed directly from
+  Emacs when the =denote= package is installed (for example, evaluate
+  =(info "(denote) Top")=), but they do not work with HTML.  Alas,
+  what we tried to do did not work.  Maybe Org has a way to control
+  what is exported where.  We shall see.  At any rate, thanks to Eshel
+  for the effort: <https://lists.sr.ht/~protesilaos/denote/patches/36028>.
+
++ All code that integrates the =denote:= custom hyperlink type with
+  Org's link facility is now assigned =autoload= cookies.  These are
+  done to ensure that =denote= is loaded and is available in cases
+  where Org needs to access a =denote:= link at some early stage
+  (e.g. at startup before using Denote).  Thanks to Sven Seebeck for
+  reporting the problem: <https://lists.sr.ht/~protesilaos/denote/%3C87r0zovwix.fsf%40svenseebeck.me%3E>.
+  Although Sven could not reproduce a bug reliably, I believe this
+  prevents such an eventuality.
+
++ Expanded or otherwise updated the manual to account for all of the
+  above, where appropriate.
+
+* Version 1.0.0 on 2022-09-30
+:PROPERTIES:
+:CUSTOM_ID: h:053975d7-3fe2-49e5-96a0-336483e5861c
+:END:
+
+This is the first major release of Denote.  A part of the changes
+documented herein is for advanced users or developers who wish to
+extend Denote with their custom code.  Though we first cover what
+applies to everyone.
+
+** Changes for all users
+:PROPERTIES:
+:CUSTOM_ID: h:25692d4f-08da-4938-a81e-54070d91f51a
+:END:
+
++ The custom Org hyperlink type of =denote:= can be visited from
+  outside the ~denote-directory~.  We now provide the necessary glue
+  code that Org needs to store these =denote:= links.  Storing them
+  can be done with an ~org-capture~ template or via the command
+  ~org-store-link~.  Use this to, for example, capture a TODO that
+  references one of your notes.
+
+  =denote:= links work for as long as the referenced file is somewhere
+  in the ~denote-directory~ or one of its subdirectories.
+
+  Thanks to Marc Fargas for the contribution.  Marc did not need to
+  assign copyright to the Free Software Foundation, as the patch was
+  within the ~15 line limit that is permissible.
+
+  The contribution was discussed on the mailing list:
+  <https://lists.sr.ht/~protesilaos/denote/patches/35137>.  A prior
+  exchange took place in issue 104 over at the GitHub mirror:
+  <https://github.com/protesilaos/denote/issues/104>.
+
+  Some further tweaks were made to the relevant function.  Thanks to
+  Elias Storms for reporting on the mailing list a bug which revealed
+  a regression I introduced to the Org link storing mechanism:
+  <https://lists.sr.ht/~protesilaos/denote/%3C15D55F4B-64D1-4083-AD5E-B5BACA8F1909%40ap.be%3E>.
+
++ Following from above, the command ~denote-link-find-file~ finds
+  files reliably, regardless of where the link is stored.  All it
+  needs is for the target file to be inside the ~denote-directory~.
+
+  I discovered this while exchanging views with Marc Fargas regarding
+  the aforementioned patch: <https://lists.sr.ht/~protesilaos/denote/patches/35137>.
+
++ The command ~denote-link-buttonize-buffer~, which "buttonizes"
+  =denote:= links in plain text and Markdown files, now performs its
+  task regardless of where the current file is stored.  Those links
+  work for as long as the file they reference is somewhere inside the
+  ~denote-directory~.
+
++ The commands ~denote-link-after-creating~, ~denote-link-or-create~
+  provide a convenience for users who need to create link to notes
+  that may not exist yet.  The idea is that one is expounding on a
+  given topic and wants to create a link to a relevant issue.  They
+  are not sure if they have written anything about it yet, so they
+  invoke the relevant command.  Consult their doc strings or read the
+  manual: <https://protesilaos.com/emacs/denote#h:9e41e7df-2aac-4835-94c5-659b6111e6de>.
+
+  Thanks to user sienic for suggesting the idea and for testing the
+  prototypes.  And thanks to Juanjo Presa for participating in the
+  discussion to share the view that this functionality should be part of
+  denote.el.  This happened in issue 96 over at the GitHub mirror:
+  <https://github.com/protesilaos/denote/issues/96>.
+
++ The command ~denote-open-or-create~ offers the convenience of
+  visiting a file, if it exists, else prompting for its creation.
+  Thanks to Alan Schmitt for the contribution.  The patch was sent on
+  the mailing list: <https://lists.sr.ht/~protesilaos/denote/%3C87fsgvddny.fsf%40protesilaos.com%3E>.
+  It is within the limit of what is allowed without assigning
+  copyright to the Free Software Foundation, though Alan has done the
+  relevant paperwork.
+
++ The manual expands on two sections: (1) Variants of
+  ~denote-open-or-create~, (2) Variants of ~denote-link-or-create~.
+  They show how one can use the above "do or create" commands with
+  different permutations of the Denote prompts for new note creation.
+
++ The manual includes a section titled "Create a note with the
+  region's contents".  Quote:
+
+  #+begin_quote
+  Sometimes it makes sense to gather notes in a single file and later
+  review it to make multiple notes out of it.  With the following
+  code, the user marks a region and then invokes the command
+  ~my-denote-create-new-note-from-region~: it prompts for a title and
+  keywords and then uses the region's contents to fill in the newly
+  created note.
+  #+end_quote
+
+  This is not part of denote.el, though we provide it in the manual
+  for users that may need it.  Thanks to sundar bp for suggesting the
+  idea.  This was done via a private channel and the information is
+  shared with permission.
+
++ The manual has another entry titled "Split an Org subtree into its
+  own note", which is similar to the above idea of using the region's
+  contents but has some extra niceties provided by Org.  Quote:
+
+  #+begin_quote
+  With Org files in particular, it is common to have nested headings which
+  could be split off into their own standalone notes.  In Org parlance an
+  entry with all its subheadings is a "subtree".  With the following code,
+  the user places the point inside the heading they want to split off and
+  invokes the command ~my-denote-split-org-subtree~.  It will create a
+  note using the heading's text and tags for the new file.  The contents
+  of the subtree become the contents of the new note and are removed from
+  the old one.
+  #+end_quote
+
+  Thanks to Sven Seebeck for suggesting the idea and for testing my
+  prototypes.  This information is shared with permission, as it was
+  provided via a private channel.
+
++ The manual describes how a user can leverage the built-in
+  ~dired-virtual-mode~ to perform arbitrary sorting of their list of
+  notes.  It also includes code for Eshell to quickly "export" a
+  command's output into a dedicated buffer (which can then be used to
+  derive a "virtual" Dired).  Thanks to Yi Liu for asking the question
+  that inspired this entry:
+  <https://lists.sr.ht/~protesilaos/denote/%3C1C75FF01-EC76-49DF-9AEB-ED718A2795FF@gmail.com%3E>.
+
++ The ~denote-faces-broken-link~ has been removed.  It was used for
+  Org links.  The idea was to apply a different style if the link was
+  broken.  However, the way fontification works means that there may
+  be a performance penalty as Org tries to check again and again if
+  the link is broken or note.  As =denote:= links are robust (unless
+  the user tries to break them), this penalty is unacceptable.  Thanks
+  to Peter Prevos for reporting the issue and discussing it with me on
+  the mailing list:
+  <https://lists.sr.ht/~protesilaos/denote/%3C87k05umyyo.fsf%40prevos.net%3E>.
+
++ The "denote" group in Custom UI buffers now provides a link to the
+  Info manual that is shipped with the package.  To read the manual,
+  evaluate =(info "(denote) Top")=.  Else visit the official web page:
+  <https://protesilaos.com/emacs/denote>.
+
++ Fixed a case where an internal check for a note would throw an error
+  if the buffer was not visiting a file.  Thanks to Hilde Rhyne was
+  the patch: it is below the ~15 line threshold and thus does not
+  require copyright assignment to the Free Software Foundation.  The
+  issue was discussed on the mailing list and was pushed to users as
+  version =0.6.1=:
+  <https://lists.sr.ht/~protesilaos/denote/%3Cm035d7nq22.fsf%40disroot.org%3E>.
+
++ When linking to a file that has no front matter, Denote tries to use
+  the TITLE component of the file name (per our file-naming scheme) as
+  the link's descriptive text.  We now make this look a bit better, by
+  capitalising only the first letter while dehyphenating the text,
+  converting =this-is-a-test= to =This is a test=.  Before, we would
+  capitalise all words.  Thanks to Clemens Radermacher for the patch.
+  It was sent via a private channel.  Clemens has assigned copyright
+  to the Free Software Foundation.
+
+** Changes for developers or advanced users
+:PROPERTIES:
+:CUSTOM_ID: h:165cd056-5e27-4536-b8ac-57f88c927a43
+:END:
+
+Lots of functions and variables which once were for "private" use (the
+presence of double hyphens in the symbol) are now made public.
+Concretely this means that they no longer have double hyphens in their
+name and we pledge to support them henceforth.  "Support" means that
+we (i) consider them stable, (ii) document them properly, (iii) will
+record any changes made to them such as in a change log, a blog post
+on my website, and via ~make-obsolete~.
+
+The manual provides a complete reference of what is on offer.  The
+section is titled "For developers or advanced users":
+<https://protesilaos.com/emacs/denote#h:c916d8c5-540a-409f-b780-6ccbd90e088e>.
+
+Normally, we do not support private forms and can delete/modify them
+without notice.  However, I decided to write obsoletion aliases for
+all forms I made public or otherwise revised, in an effort not to
+break any existing custom code.  The following table covers all
+obsolete symbols and their new counterparts.  PLEASE UPDATE YOUR CODE
+as those aliases will be removed in the near future.
+
+| Index | Old symbol                                     | New symbol                                        |
+|-------+------------------------------------------------+---------------------------------------------------|
+|     1 | denote--id-format                              | denote-id-format                                  |
+|     2 | denote--id-regexp                              | denote-id-regexp                                  |
+|     3 | denote--title-regexp                           | denote-title-regexp                               |
+|     4 | denote--keywords-regexp                        | denote-keywords-regexp                            |
+|     5 | denote--punctuation-regexp                     | denote-excluded-punctuation-regexp                |
+|     6 | denote-punctuation-excluded-extra-regexp       | denote-excluded-punctuation-extra-regexp          |
+|     7 | denote--sluggify                               | denote-sluggify                                   |
+|     8 | denote--sluggify-and-join                      | denote-sluggify-and-join                          |
+|     9 | denote--sluggify-keywords                      | denote-sluggify-keywords                          |
+|    10 | denote--desluggify                             | denote-desluggify                                 |
+|    11 | denote--only-note-p                            | denote-file-is-note-p                             |
+|    12 | denote--file-has-identifier-p                  | denote-file-has-identifier-p                      |
+|    13 | denote--file-supported-extension-p             | denote-file-has-supported-extension-p             |
+|    14 | denote--writable-and-supported-p               | denote-file-is-writable-and-supported-p           |
+|    15 | denote--file-name-relative-to-denote-directory | denote-get-file-name-relative-to-denote-directory |
+|    16 | denote-link--id-from-string                    | denote-extract-id-from-string                     |
+|    17 | denote--directory-files                        | denote-directory-files                            |
+|    18 | denote--subdirs                                | denote-directory-subdirectories                   |
+|    19 | denote--get-note-path-by-id                    | denote-get-path-by-id                             |
+|    20 | denote--directory-files-matching-regexp        | denote-directory-files-matching-regexp            |
+|    21 | denote--retrieve-read-file-prompt              | denote-file-prompt                                |
+|    22 | denote--extract-keywords-from-path             | denote-extract-keywords-from-path                 |
+|    23 | denote--keywords-prompt                        | denote-keywords-prompt                            |
+|    24 | denote--retrieve-filename-identifier           | denote-retrieve-filename-identifier               |
+|    25 | denote--file-name-id                           | denote-retrieve-or-create-file-identifier         |
+|    26 | denote--retrieve-filename-title                | denote-retrieve-filename-title                    |
+|    27 | denote--retrieve-title-value                   | denote-retrieve-title-value                       |
+|    28 | denote--retrieve-title-line                    | denote-retrieve-title-line                        |
+|    29 | denote--retrieve-keywords-value                | denote-retrieve-keywords-value                    |
+|    30 | denote--retrieve-keywords-line                 | denote-retrieve-keywords-line                     |
+|    31 | denote--format-file                            | denote-format-file-name                           |
+|    32 | denote--barf-duplicate-id                      | denote-barf-duplicate-id                          |
+|    33 | denote--title-prompt                           | denote-title-prompt                               |
+|    34 | denote--file-type-prompt                       | denote-file-type-prompt                           |
+|    35 | denote--date-prompt                            | denote-date-prompt                                |
+|    36 | denote--subdirs-prompt                         | denote-subdirectory-prompt                        |
+|    37 | denote--template-prompt                        | denote-template-prompt                            |
+|    38 | denote--filetype-heuristics                    | denote-filetype-heuristics                        |
+|    39 | denote--rename-file                            | denote-rename-file-and-buffer                     |
+|    40 | denote--rename-file-prompt                     | denote-rename-file-prompt                         |
+
+If you are writing code that extends Denote and feel that something is
+either missing or has remained private, please contact us on the
+mailing list, the GitHub/GitLab mirror, or send me an email directly.
+I always respond in a timely fashion.
+
+** Open to everyone
+:PROPERTIES:
+:CUSTOM_ID: h:27a391cf-8d5e-4d19-942f-46fc52dea80c
+:END:
+
+The most common feedback I get about Denote is that its documentation
+is good.  As you can tell from these change logs, the plan is to
+continue on this path.
+
+Please note that the communication channels for Denote (mailing list,
+mirrors, my personal email) are open to users of all levels.  Do not
+hesitate to contact us/me.
+
+Thanks again to everyone for their contributions, direct or indirect,
+either in the form of code or the discussion of ideas.  Quoting from
+the "Acknowledgements" section of the manual (all my packages have
+such a section):
+
+#+begin_quote
+Denote is meant to be a collective effort.  Every bit of help matters.
+
++ Author/maintainer :: Protesilaos Stavrou.
+
++ Contributions to code or the manual :: Abin Simon, Alan Schmitt,
+  Benjamin Kästner, Clemens Radermacher, Colin McLear, Damien Cassou,
+  Eshel Yaron, Hilde Rhyne, Jack Baty, Jean-Philippe Gagné Guay, Jürgen
+  Hötzel, Kaushal Modi, Kyle Meyer, Marc Fargas, Peter Prevos, Philip
+  Kaludercic, Quiliro Ordóñez, Stefan Monnier.
+
++ Ideas and/or user feedback :: Abin Simon, Alan Schmitt, Alfredo
+  Borrás, Benjamin Kästner, Colin McLear, Damien Cassou, Elias Storms,
+  Frank Ehmsen, Hanspeter Gisler, Jack Baty, Juanjo Presa, Kaushal
+  Modi, M. Hadi Timachi, Paul van Gelder, Peter Prevos, Shreyas
+  Ragavan, Summer Emacs, Sven Seebeck, Taoufik, Yi Liu, Ypot, atanasj,
+  hpgisler, pRot0ta1p, sienic, sundar bp.
+
+Special thanks to Peter Povinec who helped refine the file-naming
+scheme, which is the cornerstone of this project.
+
+Special thanks to Jean-Philippe Gagné Guay for the numerous
+contributions to the code base.
+#+end_quote
+
+* Version 0.6.0 on 2022-08-31
+:PROPERTIES:
+:CUSTOM_ID: h:50aba79a-d702-42b4-a2a5-7fa29033f904
+:END:
+
+Denote is in a stable state.  I consider it feature-complete, without
+prejudice to possible refinements to its existing feature set.  The next
+version shall be =1.0.0=.
+
+** User-facing changes
+:PROPERTIES:
+:CUSTOM_ID: h:566a770b-399e-47a6-9aa4-326fd6ade9a7
+:END:
+
++ The Denote linking facility can now link to any file that has the
+  Denote file-naming scheme.  Before, we limited this feature to what we
+  consider "note" files, else the supported plain text formats (per
+  ~denote-file-type~).  Thanks to Peter Prevos for the discussion on the
+  mailing list: <https://lists.sr.ht/~protesilaos/denote/%3C87fsi1m5ze.fsf%40prevos.net%3E>.
+
++ Date prompts may optionally use the familiar Org date-selection
+  mechanism that leverages the calendar.  This feature is subject to the
+  user option ~denote-date-prompt-use-org-read-date~.  A date prompt is
+  used by the ~denote-date~ command or, optionally, by the ~denote~
+  command when the user option ~denote-prompts~ is configured
+  accordingly.  The manual elaborates on the specificities.  Thanks to
+  Jean-Philippe Gagné Guay for the contribution in pull request 97 at
+  the GitHub mirror: <https://github.com/protesilaos/denote/pull/97>.
+
++ Leading empty spaces at the ~denote~ =TITLE= prompt no longer produce
+  hyphens: they are simply ignored to keep file names consistent.
+  Thanks to Peter Prevos for the contribution in pull request 99 at the
+  GitHub mirror: <https://github.com/protesilaos/denote/pull/99>.
+
+  [ Peter has started the process for copyright assignment to the Free
+    Software Foundation, though the total contributions are still within
+    the permitted boundaries. ]
+
++ When linking to files that have no front matter, the link's anchor
+  text (the human-readable part) is derived from the file name =TITLE=
+  component.  We apply a de-hyphenation and capitalisation of its
+  constituent words.  This is not always perfect, but it is better than
+  something like =this-is-the-title=.  Thanks to Peter Prevos for the
+  original idea in pull request 93 at the GitHub mirror:
+  <https://github.com/protesilaos/denote/pull/93>.
+
++ The active region is now used as the default value of the ~denote~
+  command =TITLE= prompt.  The idea behind this Do-What-I-Mean-flavoured
+  patch is to be able to take a note about a subject that appears in a
+  buffer by simply marking it before invoking the ~denote~ command.
+
+  Thanks to Eshel Yaron for the patch: <https://lists.sr.ht/~protesilaos/denote/patches/34870>.
+  It is below the ~15 line threshold that thus requires no copyright
+  assignment to the Free Software Foundation.
+
++ The ~denote-rename-file-using-front-matter~ command now offers to save
+  the buffer if appropriate.  In the past, it would simply produce an
+  error asking the user to save the buffer.  Thanks to Peter Prevos for
+  the contribution in pull request 103 at he GitHub mirror:
+  <https://github.com/protesilaos/denote/pull/103>.
+
++ Fixed the text of the confirmation prompt in the command
+  ~denote-migrate-old-markdown-yaml-tags~.  Thanks to Abin Simon for the
+  patch: <https://lists.sr.ht/~protesilaos/denote/patches/34632>.
+
+  This patchset also fixes (i) how a tag is identified for the purposes
+  of migrating old to new front matter, (ii) the regular expression for
+  Org front matter keywords
+
+  [ The total changes are below the ~15 line threshold and thus do not
+    require copyright assignment to the Free Software Foundation. ]
+
++ Fixed a bug that prevented the creation of new notes.  Thanks to
+  Juergen Hoetzel for the contribution in pull request 84 at the GitHub
+  mirror: <https://github.com/protesilaos/denote/pull/84>.  This was
+  done immediately after the release of version =0.5.0= on 2022-08-10
+  and was provided to users as version =0.5.1=
+
+  [ The change is below the ~15 line threshold. ]
+
+** Internal refinements
+:PROPERTIES:
+:CUSTOM_ID: h:9374b533-faaa-4ab4-b668-f74b5eae7ab5
+:END:
+
+These make the code simpler and more predictable.  As the individual
+changes are not user-facing, I invite interested parties to consult the
+Git log.  Special thanks to Jean-Philippe Gagné Guay for the multiple
+contributions (and relevant discussions) over at the GitHub mirror:
+
+- <https://github.com/protesilaos/denote/pull/88>
+- <https://github.com/protesilaos/denote/pull/89>
+- <https://github.com/protesilaos/denote/pull/91>
+- <https://github.com/protesilaos/denote/pull/94>
+- <https://github.com/protesilaos/denote/pull/101>
+- <https://github.com/protesilaos/denote/pull/102>
+
+[ Jean-Philippe has assigned copyright to the Free Software Foundation.
+  It is required for non-trivial changes. ]
+
+** For advanced users
+:PROPERTIES:
+:CUSTOM_ID: h:c6fc05a2-ff31-4a0c-91a1-f64d2cfd6a16
+:END:
+
+The variable ~denote-file-types~ is an alist of plists which
+substantiates the supported file types (per the user option
+~denote-file-type~).  Properties pertain to the formatting of front
+matter and the retrieval of relevant values.  The doc string of
+~denote-file-types~ explains the details, while the default value uses
+the ancillary functions we define.  Thanks to Jean-Philippe Gagné Guay
+for the relevant contributions in pull request 89 at the GitHub mirror:
+<https://github.com/protesilaos/denote/pull/89>.
+
+
+* Version 0.5.0 on 2022-08-10
+:PROPERTIES:
+:CUSTOM_ID: h:80b9daaa-c3c8-4457-b109-966bb6a99832
+:END:
+
+The general theme of this release is to refine what we already offer.
+As I explained in some discussions, Denote is feature-complete.  We can
+always improve the code or add some ancillary function/command/variable,
+though all the main ideas have already been implemented.  Additional
+functionality can be provided by other packages: I remain at the
+disposal of anyone willing to write such a package.
+
+The present release covers more than 150 commits since version 0.4.0 on
+2022-07-25.
+
+All release notes: <https://protesilaos.com/emacs/denote-changelog>.
+
+** Templates for new notes
+:PROPERTIES:
+:CUSTOM_ID: h:0878125f-8392-48e6-aeff-1469eb1e18fc
+:END:
+
+We now provide the ~denote-templates~ user option.  A "template" is
+arbitrary text that Denote will add to a newly created note right below
+the front matter.
+
+Templates are expressed as a =(KEY . STRING)= association.
+
+- The =KEY= is the name which identifies the template.  It is an
+  arbitrary symbol, such as =report=, =memo=, =statement=.
+
+- The =STRING= is ordinary text that Denote will insert as-is.  It can
+  contain newline characters to add spacing.  The manual of Denote
+  contains examples on how to use the ~concat~ function, beside writing
+  a generic string:
+  <https://protesilaos.com/emacs/denote#h:f635a490-d29e-4608-9372-7bd13b34d56c>.
+
+The user can choose a template either by invoking the new command
+~denote-template~ or by changing the user option ~denote-prompts~ to
+always prompt for a template when calling the ~denote~ command.
+
+Thanks to Jean-Philippe Gagné Guay for refinements to this facility.
+Done in pull request 77 on the GitHub mirror:
+<https://github.com/protesilaos/denote/pull/77>.
+
+[ Jean-Philippe has assigned copyright to the Free Software Foundation. ]
+
+** Revised format for Org =#+filetags= entry
+:PROPERTIES:
+:CUSTOM_ID: h:17688b79-cb1b-4a59-831e-fbf2a81245d3
+:END:
+
+Denote used to format tags in Org files by separating them with two
+spaces:
+
+#+begin_example
+#+filetags:  tag1  tag2
+#+end_example
+
+While this worked for some obvious use-cases, it is not supported by
+Org.  The Org documentation stipulates that tags be separated by the
+colon sign.  The above would then be written thus:
+
+#+begin_example
+#+filetags:  :tag1:tag2:
+#+end_example
+
+Denote now conforms with Org's specifications.  To help users update
+their existing notes, we provide the ~denote-migrate-old-org-filetags~
+command.  It will perform the conversion in all Org files that had the
+old notation.  As with all Denote operations that rewrite file contents,
+it DOES NOT SAVE BUFFERS.  The user is expected to review the changes,
+such as by using ~diff-buffer-with-file~.  Multiple buffers can be saved
+with ~save-some-buffers~ (check its doc string).
+
+This command is provided for the convenience of the user.  It shall be
+deprecated and eventually removed from future versions of Denote.
+
+If you need help with any of this, please do not hesitate to contact me
+either in private or in one of Denote's official channels (mailing list,
+GitHub/GitLab mirror).
+
+Thanks to Alan Schmitt for bringing this matter to my attention:
+<https://lists.sr.ht/~protesilaos/denote/%3C871qu0jw5l.fsf%40protesilaos.com%3E>.
+Also thanks to Jean-Philippe Gagné Guay for commenting on it as it
+helped me decide to include the command in =denote.el=:
+<https://github.com/protesilaos/denote/pull/83#issuecomment-1210167133>.
+
+** Revised format for Markdown+YAML =tags:= entry
+:PROPERTIES:
+:CUSTOM_ID: h:205a09cf-0159-425e-a6b3-41700fa3ad31
+:END:
+
+This is the same idea as above.  Before, we were making the mistake of
+using incorrect YAML notation:
+
+#+begin_src yaml
+tags:  tag1  tag2
+#+end_src
+
+Now we do:
+
+#+begin_src yaml
+tags:  ["tag1", "tag2"]
+#+end_src
+
+This is how the TOML variant always worked.
+
+For the user's convenience, we provide a command to migrate from the old
+to the new syntax: ~denote-migrate-old-markdown-yaml-tags~.
+
+** Changes to file renaming and front matter rewriting
+:PROPERTIES:
+:CUSTOM_ID: h:15ecb4e8-d1ce-4e42-b74d-a3a046d93220
+:END:
+
+Denote adds "front matter" to newly created notes which includes data
+such as the title and keywords/tags of the document.  Strictly speaking,
+the front matter is not required by Denote.  It is provided for the
+user's convenience, such as for readability or if they want to use the
+note with other programs (e.g. Org export, a blog with Hugo/Jekyll,
+...).
+
+Denote provides commands which help the user rename their notes, by
+changing the file name's =TITLE= and/or =KEYWORDS= components (per
+Denote's file-naming scheme).  These commands also operate on the front
+matter to keep the data between file name and file contents in sync
+(again, for the user's convenience).
+
+For this release we have consolidated and refined our offerings in order
+to improve their ergonomics.  All changes are the result of fruitful
+discussions on the mailing list and the issue tracker of the GitHub
+mirror:
+
+- <https://lists.sr.ht/~protesilaos/denote/%3C87k081l6vw.fsf%40silverstone.mail-host-address-is-not-set%3E>
+- <https://lists.sr.ht/~protesilaos/denote/%3C878rogw5kk.fsf%40protesilaos.com%3E>
+- <https://lists.sr.ht/~protesilaos/denote/%3C87fsiljv1s.fsf%40hu.mail-host-address-is-not-set%3E>
+- <https://lists.sr.ht/~protesilaos/denote/%3C87r122afe3.fsf%40hu.mail-host-address-is-not-set%3E>
+- <https://github.com/protesilaos/denote/issues/74>
+
+Thanks to (A-Z) Hanspeter Gisler, Jean-Philippe Gagné Guay, and Peter
+Prevos for their participation.
+
+Also thanks to Jean-Philippe Gagné Guay for relevant code contributions
+(please consult the Git log for the minutiae):
+
+- <https://github.com/protesilaos/denote/pull/66>
+- <https://github.com/protesilaos/denote/pull/67>
+- <https://github.com/protesilaos/denote/pull/69>
+- <https://github.com/protesilaos/denote/pull/75>
+- <https://github.com/protesilaos/denote/pull/76>
+
+*** Renaming a single file
+:PROPERTIES:
+:CUSTOM_ID: h:1d695e54-1481-42dd-916b-c0542c48aa6f
+:END:
+
+The commands ~denote-dired-rename-file-and-add-front-matter~ and
+~denote-dired-rename-file~ are deprecated and superseded by the new
+~denote-rename-file~.  Please update any key bindings in your setup.
+
+The difference between the old commands and the new ~denote-rename-file~
+is that the latter will now insert front matter to supported file types
+(per ~denote-file-type~) if they have none.  This basically means that,
+e.g., renaming a generic Org/Markdown/Plain text file with
+~denote-rename-file~ will update its file name to comply with Denote's
+file-naming scheme and also add the appropriate front matter (it
+"converts" it to a Denote note).  If front matter exists, this command
+will rewrite it to reflect the changes to the file name's =TITLE= and/or
+=KEYWORDS=.
+
+Consult the manual for the details:
+<https://protesilaos.com/emacs/denote#h:7cc9e000-806a-48da-945c-711bbc7426b0>.
+
+Or, if the new version of the GNU ELPA package is installed, evaluate:
+
+#+begin_src emacs-lisp
+(info "(denote) Rename a single file")
+#+end_src
+
+The user option ~denote-dired-rename-expert~ is obsolete.  Denote always
+asks for confirmation when renaming a single file.  This is because the
+user can rely on batch-renaming commands which ask for confirmation only
+once per batch.
+
+*** Renaming multiple files at once
+:PROPERTIES:
+:CUSTOM_ID: h:82455fb4-576b-4753-af66-ac48fd158327
+:END:
+
+The command ~denote-dired-rename-marked-files-and-add-front-matter~ is
+deprecated and its functionality is absorbed by the existing
+~denote-dired-rename-marked-files~ command.  The deprecated command was
+used to insert front matter to supported file types (per
+~denote-file-type~) that had none.  We now handle this internally, thus
+streamlining the experience for the user.
+
+Refer to the manual for the details:
+<https://protesilaos.com/emacs/denote#h:1b6b2c78-42f0-45b8-9ef0-6de21a8b2cde>
+
+Assuming the latest Info manual is installed, evaluate:
+
+#+begin_src emacs-lisp
+(info "(denote) Rename multiple files at once")
+#+end_src
+
+*** Renaming a single file based on its front matter
+:PROPERTIES:
+:CUSTOM_ID: h:d913e369-9325-46c4-985b-cf5b3e35372b
+:END:
+
+Introduced the ~denote-rename-file-using-front-matter~ command.  This is
+new functionality we provide which uses the front matter as input to
+perform a rename of the file.  The aforementioned offerings prompt for
+input via the minibuffer and propagate the changes firstly to the file
+name and subsequently to the front matter.  Whereas with the command
+~denote-rename-file-using-front-matter~, the user can edit the front
+matter manually and then invoke the command to pass the changes to the
+file name, subject to a confirmation.  Relevant entries are the title
+and tags/filetags (depending on the file type).  The date and the
+identifier are not pertinent.  Identifiers in file names are NEVER
+rewritten by Denote.
+
+Consult the manual:
+<https://protesilaos.com/emacs/denote#h:3ab08ff4-81fa-4d24-99cb-79f97c13a373>.
+
+With the latest package, evaluate:
+
+#+begin_src emacs-lisp
+(info "(denote) Rename a single file based on its front matter")
+#+end_src
+
+*** Renaming multiple files based on their front matter
+:PROPERTIES:
+:CUSTOM_ID: h:4efc6c14-fd71-4bd8-8bb1-e8e720b98eff
+:END:
+
+The command ~denote-dired-rename-marked-files-using-front-matter~
+completes the set of features we provide for syncing between file name
+and front matter.  It applies to all marked files in a Dired buffer.
+
+Read the manual to understand how the command works and what it does
+exactly: <https://protesilaos.com/emacs/denote#h:ea5673cd-e6ca-4c42-a066-07dc6c9d57f8>.
+
+Or evaluate:
+
+#+begin_src emacs-lisp
+(info "(denote) Rename multiple files based on their front matter")
+#+end_src
+
+*** Add missing front matter on demand
+:PROPERTIES:
+:CUSTOM_ID: h:32a103be-71a2-48e4-a18e-7727c04545ed
+:END:
+
+Sometimes the user may have incomplete front matter, perhaps due to a
+mistake that was saved on disk.  The command ~denote-add-front-matter~
+appends a new front matter block to the current note.
+
+Read:
+<https://protesilaos.com/emacs/denote#h:54b48277-e0e5-4188-ad54-ef3db3b7e772>
+
+Or evaluate:
+
+#+begin_src emacs-lisp
+(info "(denote) Regenerate front matter")
+#+end_src
+
+** Faces for Denote links
+:PROPERTIES:
+:CUSTOM_ID: h:507fb46c-a2e9-48a7-8cd2-53c5fc73394d
+:END:
+
+We provide the ~denote-faces-link~ and the ~denote-faces-broken-link~.
+The latter is only relevant for Org, as Emacs' standard button mechanism
+does not have a way to apply a face dynamically.
+
+This is a change for themes/tinkerers who need to differentiate
+=denote:= links from other links.  Otherwise, the presentation is the
+same as before.
+
+Thanks to Peter Prevos for asking about it on the mailing list:
+<https://lists.sr.ht/~protesilaos/denote/%3C03618bb20d3eaba78c32cd0cb63bfc71%40prevos.net%3E>.
+
+** Use of XDG path in ~denote-directory~
+:PROPERTIES:
+:CUSTOM_ID: h:efa3049e-f1fa-48ff-af7d-d16edc677704
+:END:
+
+The default value of the ~denote-directory~ user option used to be
+=~/Documents/notes= (subject to some conversion via Elisp).  Denote now
+conforms with the freedesktop.org specifications by using the =XDG=
+directory for =DOCUMENTS= instead of =~/Documents=:
+<https://www.freedesktop.org/wiki/Software/xdg-user-dirs/>.
+
+Users who already bind the ~denote-directory~ are not affected by this
+change.  Same for those who do not tinker with =XDG= environment
+variables and/or do not use some exotic setup.
+
+Thanks to Philip Kaludercic for the patch:
+<https://lists.sr.ht/~protesilaos/denote/patches/34561#%3C20220809115824.43089-1-philipk@posteo.net%3E>
+
+** Bespoke major-mode for the backlinks' buffer
+:PROPERTIES:
+:CUSTOM_ID: h:feb9a0ed-ba15-486e-ae11-5b222b00bc31
+:END:
+
+The backlinks' buffer now uses the ~denote-backlink-mode~ instead of the
+generic ~special-mode~.  The former derives from the latter.  It binds
+keys to move between links with =n= (next) and =p= (previous).  These
+are stored in the ~denote-backlink-mode-map~ (use =M-x describe-mode=
+(=C-h m=) in an unfamiliar buffer to learn more about it).
+
+Thanks to Philip Kaludercic for the patch:
+<https://lists.sr.ht/~protesilaos/denote/patches/34561#%3C20220809115824.43089-2-philipk@posteo.net%3E>
+
+** Changes to the manual
+:PROPERTIES:
+:CUSTOM_ID: h:80217a39-86b8-4310-b7c4-dcc14e0b98fd
+:END:
+
++ Documented all of the aforementioned.  Improved how information is
+  presented and, generally, iterated on an already comprehensive
+  document.
+
++ Introduced a node which explains how to tweak the front matter:
+  <https://protesilaos.com/emacs/denote#h:7f918854-5ed4-4139-821f-8ee9ba06ad15>.
+  Or evaluate:
+
+  #+begin_src emacs-lisp
+  (info "(denote) Change the front matter format")
+  #+end_src
+
++ Updated the reference to =consult-notes=.  This is a package that uses
+  the =consult= interface to provide access and search facilities for
+  notes.  It can integrate with Denote.  Thanks to Colin McLear for the
+  change in pull request 70 on the GitHub mirror:
+  <https://github.com/protesilaos/denote/pull/70>.
+
+  [ The change is below the ~15 line threshold and thus does not require
+    copyright assignment to the Free Software Foundation. ]
+
+** Internal restructuring
+:PROPERTIES:
+:CUSTOM_ID: h:5d09d0af-3c25-4419-8448-90b8e1adab0d
+:END:
+
++ All Denote code is consolidated in =denote.el=.  We no longer maintain
+  separate files like =denote-link.el=, =denote-dired.el=, etc.  Users
+  who had ~require~ calls to such libraries must remove them and only
+  keep:
+
+  #+begin_src emacs-lisp
+  (require 'denote)
+  #+end_src
+
++ User options that have an entry in the manual will now provide a link
+  to it via their Help buffer and/or the Custom UI.  This is done by
+  adding the =:link= attribute to their declaration.
+
+  Furthermore, user options and faces now specify the version of Denote
+  that last affected their value (e.g. ~denote-directory~, which was
+  mentioned above for the XDG spec, now informs the user that it changed
+  for version =0.5.0=).
+
+  [ I learnt these by developing the =modus-themes=. ]
+
++ The variables ~denote-last-title~, ~denote-last-keywords~,
+  ~denote-last-buffer~, and ~denote-last-front-matter~ are all obsolete.
+  These were used prior to version =0.1.0= to help with development but
+  are now deemed surplus to requirements.
+
++ Lots of changes were made to private functions, variables, doc
+  strings, and comments, in the interest of simplifying the code and/or
+  ensuring consistency in how operations are carried out.  Though
+  everything is the same for the end-user.
+
+Thanks to Jean-Philippe Gagné Guay for the numerous contributions on the
+GitHub mirror.  They are important for Denote, though the user does not
+need to know what is happening internally (consult the Git log for the
+details):
+
+- <https://github.com/protesilaos/denote/pull/65>
+- <https://github.com/protesilaos/denote/pull/72>
+- <https://github.com/protesilaos/denote/pull/73>
+- <https://github.com/protesilaos/denote/pull/78>
+- <https://github.com/protesilaos/denote/pull/80>
+- <https://github.com/protesilaos/denote/pull/81>
+- <https://github.com/protesilaos/denote/pull/82>
+- <https://github.com/protesilaos/denote/pull/83>
+
+** Discussions
+:PROPERTIES:
+:CUSTOM_ID: h:79089c06-9e0c-49cc-9d53-a1a2fd72fb65
+:END:
+
+*** Encrypting Denote notes
+:PROPERTIES:
+:CUSTOM_ID: h:87e4556a-4864-4955-a98c-62b2e6a509c3
+:END:
+
+Paul van Gelder asked about this on the mailing list.  I provided
+guidelines on what can be done, though did not record anything in the
+manual: I prefer to elicit more feedback from users.  The gist is that
+Emacs already has all the requisite functionality, though encryption per
+se is outside the scope of Denote:
+<https://lists.sr.ht/~protesilaos/denote/%3C1123434736.64290.1658954014673%40kpc.webmail.kpnmail.nl%3E>.
+
+Denote's relevant internal mechanisms will recognise files ending in
+=.gpg= (e.g. for fontification in Dired).
+
+*** Visualise usage of Denote keywords
+:PROPERTIES:
+:CUSTOM_ID: h:d94ee5e3-0a54-404c-b44b-34edc3703fbc
+:END:
+
+Peter Prevos shared a proof-of-concept way to visualise keywords in the
+~denote-directory~ and show usage statistics:
+<https://lists.sr.ht/~protesilaos/denote/%3Ce9e5d6ae85984b51067b47f4d8e134fa%40prevos.net%3E>.
+
+We do not include this information in the manual, as we wait for the
+fully fledged code.  Though do give it a try if you are interested and,
+perhaps, share your thoughts for Peter's consideration.
+
+*** Conflict between ~denote-dired-mode~ and ~diredfl-mode~
+:PROPERTIES:
+:CUSTOM_ID: h:0cbf504c-676c-436e-8ae8-e7115368e691
+:END:
+
+Hilde Rhyne shared a workaround they have to disable ~diredfl-mode~ in
+the buffers where ~denote-dired-mode~ is enabled.  The conflict between
+the two is a known issue that is acknowledged in the manual:
+<https://lists.sr.ht/~protesilaos/denote/%3Cm0tu6q6bg0.fsf%40disroot.org%3E>.
+
+I think we need a proper solution in the code we provide, so this
+workaround is not mentioned in the manual.
+
+*** Why doesn't Denote provide a search facility?
+:PROPERTIES:
+:CUSTOM_ID: h:068108f4-a4fa-4ff8-be49-f1f10a862451
+:END:
+
+There was a discussion started by Fourchaux, with the participation of
+basaran and Andre0991 on the GitHub mirror:
+<https://github.com/protesilaos/denote/issues/71>.
+
+The gist of my answer is that Denote does not need to provide such a
+facility because notes are ordinary files: whatever the user already has
+for them should apply to Denote.  If the user has nothing to search
+through files, they anyhow need something that works outside the
+confines of Denote: a =denote-SEARCH= command is not an adequate
+solution.
+
+Emacs has numerous built-in commands, such as ~grep~ (~lgrep~ and
+~rgrep~), ~project-find-regexp~, ~find-grep-dired~, ~ibuffer-do-occur~,
+...  Furthermore, there are lots of high quality packages that have
+their own wrappers or extensions for searching file contents, such as
+the =ivy= and =helm= completion frameworks, as well as =consult= (the
+commands ~consult-grep~ and ~consult-ripgrep~), =consult-notes=, =rg=,
+=deadgrep=, =deft=, and probably plenty more that do not come to mind
+right now.
+
+I strongly encourage the user to find a universal search solution to the
+problem of searching file contents.
+
+* Version 0.4.0 on 2022-07-25
+:PROPERTIES:
+:CUSTOM_ID: h:1c8098ee-089c-4511-bc6a-4140aab01321
+:END:
+
++ Defined the ~denote-link-dired-marked-notes~ command.  It lets the
+  user produce a typographic list of links to the note files that are
+  marked in Dired.  The list is written at point.  If there are multiple
+  buffers which visit Denote notes, the command first prompts with
+  minibuffer completion for one among them.
+
+  In terms of workflow, ~denote-link-dired-marked-notes~ complements the
+  ~denote-link-add-links~ command for those cases where it is easier to
+  select files than write an elegant regular expression.
+
++ Implemented the ~denote-dired-rename-marked-files~ command.  This
+  provides a much-requested facility to perform the familiar renaming
+  operation on a set of files.  In particular:
+
+  - the file's existing file name is retained and becomes the =TITLE=
+    field, per Denote's file-naming scheme;
+
+  - the =TITLE= is sluggified and downcased, per our conventions;
+
+  - an identifier is prepended to the =TITLE=;
+
+  - the file's extension is retained;
+
+  - a prompt is asked once for the =KEYWORDS= field and the input is
+    applied to all file names;
+
+  - if the file is recognised as a Denote note, the command rewrites its
+    front matter to include the new keywords.  A confirmation to carry
+    out this step is performed once at the outset.  Note that the
+    affected buffers are not saved.  The user can thus check them to
+    confirm that the new front matter does not cause any problems
+    (e.g. with the command ~diff-buffer-with-file~).  Multiple buffers
+    can be saved with ~save-some-buffers~ (read its doc string).
+
+  Parts of ~denote-dired-rename-marked-files~ were added or refined over
+  a series of commits.  Consult the Git log for the minutia.  Thanks to
+  Jean-Philippe Gagné Guay for the relevant additions in pull requests
+  51 and 52 on the GitHub mirror:
+
+  - <https://github.com/protesilaos/denote/pull/51>
+  - <https://github.com/protesilaos/denote/pull/52>
+
+  Jean-Philippe has assigned copyright to the Free Software Foundation.
+
++ Improved how the ~denote-dired-rename-file~ command rewrites front
+  matter.  Before, it would perform a replacement of the whole block,
+  which had the adverse effect of overwriting custom front matter
+  entries.  Now, it only targets the lines which hold the title and
+  keywords, leaving everything else intact.  Thanks to Peter Prevos for
+  reporting the problem and testing the solution to it in issue 60 on
+  the GitHub mirror: <https://github.com/protesilaos/denote/issues/60>.
+
++ Introduced the ~denote-dired-rename-file-and-add-front-matter~ command
+  that always prepends front matter to a file whose extension is among
+  the supported ones (per the user option ~denote-file-type~).  This
+  differs from the standard ~denote-dired-rename-file~ command which
+  only rewrites the front matter's title and keywords if they exist.
+
+  In practice, ~denote-dired-rename-file-and-add-front-matter~ empowers
+  the user to convert a generic text file to a Denote note.
+
+  This command was originally added by Jean-Philippe Gagné Guay in pull
+  request 49 on the GitHub mirror and refined in subsequent commits:
+  <https://github.com/protesilaos/denote/pull/49>.  Also read issue 48
+  where this idea was originally discussed:
+  <https://github.com/protesilaos/denote/issues/48>.
+
++ Added the ~denote-dired-rename-marked-files-and-add-front-matters~
+  command, which is like the ~denote-dired-rename-marked-files~ but adds
+  front matter instead of rewriting existing one, just how the command
+  ~denote-dired-rename-file-and-add-front-matter~ does it (both are
+  mentioned above).  Thanks to Jean-Philippe Gagné Guay for the
+  refinements to it in pull request 53 on the GitHub mirror:
+  <https://github.com/protesilaos/denote/pull/53>.
+
++ Wrote an interactive spec for ~denote-link-buttonize-buffer~.  It can
+  now be invoked with =M-x= or a key binding, should the need arise.
+  This function is normally called via a hook and takes effect in plain
+  text as well as Markdown files.
+
++ Extended the fontification rules so that file names with non-ASCII
+  characters are styled properly.  This issue was brought up on the
+  mailing list by Frank Ehmsen and was discussed with the participation
+  of Peter Prevos:
+  <https://lists.sr.ht/~protesilaos/denote/%3C2273b3b1-344c-6c6e-3ab6-a227b6bc3721%40eh-is.de%3E>.
+
+  The same topic was raised at the same time on the GitHub mirror by
+  user hpgisler in issue 61:
+  <https://github.com/protesilaos/denote/issues/61>.
+
+  After some discussion, we agreed on the right approach, which was
+  formalised by Peter Prevos as pull request 64 on the GitHub mirror:
+  <https://github.com/protesilaos/denote/pull/64>.  The change is below
+  the ~15 line threshold and thus does not require copyright assignment
+  to the Free Software Foundation.
+
++ Made the registration of the =denote:= custom Org hyperlink type
+  conditional on the availability of the ~org~ feature.  In other words,
+  those who do not use Org will not be loading this part of the code.
+  Thanks to Abin Simon for reporting the problem and for showing how
+  Elfeed handles this case.  This was done in issue 47 on the GitHub
+  mirror: <https://github.com/protesilaos/denote/issues/47>.
+
++ Ensured that duplicate keywords are not produced by the relevant
+  prompt.  Thanks to user Taoufik for the contribution in pull request
+  50 on the GitHub mirror: <https://github.com/protesilaos/denote/pull/50>.
+  The change is below the ~15 line threshold and thus does not require
+  copyright assignment to the Free Software Foundation.
+
++ Fixed a typo in the reference to the ~crm-separator~ in the manual.
+  David Wilson (System Crafters channel) spotted the error in a recent
+  live stream whose main topic was about Denote (thanks, by the way!):
+  <https://www.youtube.com/watch?v=QcRY_rsX0yY>.
+
++ Addressed an inconsistency in the command ~denote-link-find-file~
+  where it would not recognise links without a title in their format
+  (those can be inserted by passing a prefix argument (=C-u= by default)
+  to the commands that insert links, such as ~denote-link~).
+
++ Attached conditionality to the ~denote~ command's =SUBDIRECTORY=
+  argument, so that it does not create new file paths.  This is only
+  relevant for those who call ~denote~ from Lisp.  Interactive use is
+  the same as before.
+
++ Clarified that the user option ~denote-org-capture-specifiers~ can
+  accept arbitrary text in addition to the formatting specifiers that
+  Org's capture mechanism introduces.
+
++ Explained in the manual why ~denote-org-capture-specifiers~ is needed
+  instead of writing the capture template directly the way one normally
+  does.  The gist is that because our file names are derived dynamically
+  based on user input, we need to account for the sequence in which the
+  value of arguments is reified by ~org-capture~.
+
++ Refactored how notes are prepared internally.  Thanks to Jean-Philippe
+  Gagné Guay for the contribution in pull request 55 on the GitHub
+  mirror: <https://github.com/protesilaos/denote/pull/55>.
+
++ Declared the ~denote-punctuation-excluded-extra-regexp~ variable which
+  is, for the time being, targeted at experienced users.  Its purpose is
+  to extend what we consider "illegal" punctuation for the file name.
+  Thanks to pRot0ta1p for the feedback in issue 57 over at the GitHub
+  mirror: <https://github.com/protesilaos/denote/issues/57>.  Example
+  based on the input of pRot0ta1p:
+
+  #+begin_src emacs-lisp
+  (setq denote-punctuation-excluded-extra-regexp
+        "[『』〖〗｛｝「」【】〔〕［］（）《》〈〉«»！＃￥％…＆＂＇＊，。；：、？—]*")
+  #+end_src
+
+  The ideal is to make ~denote--punctuation-regexp~ work for all
+  scripts, but that may be unrealistic.
+
++ Clarified what the manual means by "attachments" to notes.  Those are
+  for Org, if the user resorts to the relevant Org mechanisms.  Denote
+  does not do any of that.
+
++ Revised the parsing of a date input as used in the ~denote-date~
+  command or related.  The idea is to turn =2020-01-15= into something
+  like =2020-01-15 16:19= by using the current time, so that the hour
+  and minute component is not left to =00:00= when the user does not
+  specify it explicitly.
+
+  This reduces the burden on the user who would otherwise need to input
+  the time value in order to avoid the error of duplicate identifiers in
+  the scenario where the same date is used more than once.
+
+  The change also addresses a difference between Emacs 28 and Emacs 29
+  where the former does not read dates without a time component.
+
+  Thanks to Peter Prevos for the feedback in issue 58 over at the GitHub
+  mirror: <https://github.com/protesilaos/denote/issues/58>.
+
++ Fixed compilation warnings in Emacs 29 about the format of doc strings
+  that need to output a literal single quote.  Thanks to Kyle Meyer for
+  the patch, which was sent on the mailing list:
+  <https://lists.sr.ht/~protesilaos/denote/patches/34117>.
+
++ Fixed typo in the user option ~denote-prompts~ about the
+  ~crm-separator~.  Thanks to Kyle Meyer for the patch, which was sent
+  on the mailing list:
+  <https://lists.sr.ht/~protesilaos/denote/patches/34116>.
+
++ Made the built-in =subr-x= library a runtime dependency, due to
+  complications with the ~when-let*~ form.  The problem was made
+  manifest in a renaming operation, though it was not about renaming per
+  se.  Thanks to hpgisler for reporting the problem in issue 62 and for
+  testing the proposed solution:
+  <https://github.com/protesilaos/denote/issues/62>.
+
++ Streamlined the use of the =seq= library instead of =cl-lib=, as we
+  were already using the former more heavily and there was no need for
+  the latter.  Thanks to Philip Kaludercic for pointing this out on the
+  emacs-devel mailing list:
+  <https://lists.gnu.org/archive/html/emacs-devel/2022-07/msg00838.html>.
+
++ Added a generic =README.md= file to placate the Git forges.  Neither
+  SourceHut nor GitHub/GitLab are fully compliant with the Org markup we
+  use in =README.org= (we use Org because it is easy to generate the
+  Info manual and HTML pages out of it).  SourceHut will not render the
+  file at all, while the others render it but do not parse it properly.
+
++ Made several other internal tweaks and refinements in the interest of
+  robustness and/or clarity.
+
++ Rewrote all relevant documentation.
+
+** Non-changes
+:PROPERTIES:
+:CUSTOM_ID: h:0ac79968-a575-4380-addc-d58cc2b5f627
+:END:
+
+The following are not part of any changes that were made during this
+release cycle, though they provide potentially interesting insight into
+the workings of the project.
+
++ Identifiers with milliseconds :: Denote's identifier format extends up
+  to seconds.  This is the product of years of experimentation and is,
+  in my opinion, the best compromise between usability/readability and
+  precision.  If a user produces two notes within a fraction of a
+  second, then yes they will have duplicate identifiers.  In principle,
+  there is no reason not to address this potential problem, provided we
+  do not compromise on Denote's file-naming scheme (making the
+  identifier less readable is a compromise).  We shall see what the best
+  course of action is.  Thanks to Felipe Balbi and Jean-Philippe Gagné
+  Guay for the discussion thus far in issue 54 on the GitHub mirror:
+  <https://github.com/protesilaos/denote/issues/54>.
+
++ Denote and evil-mode :: Users of evil-mode do not have to worry about
+  Denote, as we do not define any key bindings.  The manual includes
+  sample configuration, which proposes some key bindings, but that is
+  the user's prerogative.  Thanks to Saša Janiška and Alan Schmitt for
+  their participation on the mailing list:
+  <https://lists.sr.ht/~protesilaos/denote/%3C87czdxf1dz.fsf%40atmarama.ddns.net%3E>.
+
++ Denote and Citar :: Peter Prevos started developing a package that
+  connects Denote with Citar: <https://github.com/pprevos/denote-citar>.
+  The idea is to use notes as part of one's bibliography.  Discussions
+  which include sample code on how to leverage ~denote~ from Lisp:
+
+  - <https://lists.sr.ht/~protesilaos/denote/%3C6add8bc63cab0a557fa4b9919e025afc%40prevos.net%3E>
+  - <https://lists.sr.ht/~protesilaos/denote/%3C87r12d2w96.fsf%40protesilaos.com%3E>
+  - <https://lists.sr.ht/~protesilaos/denote/%3C87a69060q6.fsf%40protesilaos.com%3E>
+
++ Denote and graph of connections :: Saša Janiška asked whether Denote
+  will provide some way to visualise links between notes.  The answer is
+  negative.  Denote's scope is clearly delineated and its feature set is
+  largely complete (notwithstanding refinements to what we already
+  provide).  Peter Prevos is experimenting with some code that uses the
+  R language.  Any such facility will have to be implemented as a
+  separate package.  I remain at the disposal of anyone who needs help
+  with Denote's internals.  Thanks to the aforementioned fellows for
+  their participation on the mailing list:
+  <https://lists.sr.ht/~protesilaos/denote/%3C878roleze1.fsf%40atmarama.ddns.net%3E>.
+
++ Denote's scalability :: There was a discussion whether Denote will
+  work well with very large sets of files.  The short answer is that it
+  will work the same way Emacs and/or standard Unix tools do: good
+  enough!  If there are improvements to be made, which do not jeopardise
+  the principles of the project, we shall implement them without
+  hesitation.  Thanks to Saša Janiška and Peter Prevos for their
+  participation on the mailing list:
+  <https://lists.sr.ht/~protesilaos/denote/%3C87sfmtf7im.fsf%40atmarama.ddns.net%3E>.
+
++ Denote's minimum requirement of Emacs 27.2 :: We cannot depend on
+  Emacs 27.1 due to this message from the byte compiler:
+
+  : You should depend on (emacs "27.2") or the (org "9.3") package if you need `org-link-open-as-file'.
+
+  Depending on Org is not an option because Denote optionally works
+  without Org, so Emacs 27.2 is what we have to opt for.  If your
+  operating system does not provide this version in package format,
+  please petition its maintainers/providers to do so.  Thanks to
+  Alexander for asking about it on the mailing list:
+  <https://lists.sr.ht/~protesilaos/denote/%3C9ec818e6a7979efbb2f8b1f5a497665b%40purelymail.com%3E>.
+
+Finally, a mildly interesting piece of trivia: we have exceeded 600
+commits since the first day of the project's Git history on 2022-06-04
+(the actual history is much longer).  That averages to more than 10 per
+day!  I think things will slow down eventually.
+
+* Version 0.3.0 on 2022-07-11
+:PROPERTIES:
+:CUSTOM_ID: h:6864cfd4-d0be-4c89-b313-39ba6e892a03
+:END:
+
++ Fixed how references are analysed to produce the backlinks' buffer.
+  This should resolve the issue that some users faced where the
+  backlinks would not be produced.
+
+  The previous implementation would not yield the appropriate results if
+  (i) the value of the user option ~denote-directory~ was a "project"
+  per the built-in project.el and (ii) the link to the given entry was
+  from a subdirectory.  In short, the references were sometimes returned
+  as relative file paths, whereas they should always be absolute.
+  Thanks to Jean-Philippe Gagné Guay for the feedback in issue 42 over
+  at the GitHub mirror: <https://github.com/protesilaos/denote/pull/42>.
+
+  [ Jean-Philippe has assigned copyright to the Free Software
+    Foundation.  It is a prerequisite for contributing to core Emacs
+    and/or any package distributed via the official GNU ELPA. ]
+
++ Addressed a regression in the function ~denote-directory~ (this is the
+  function that normalises the variable of the same name) which
+  prevented it from returning an expanded file path.  This too
+  contributed to problems with the backlinking facility.  Thanks to
+  Jean-Philippe Gagné Guay for the contribution in pull request 44 over
+  at the GitHub mirror: <https://github.com/protesilaos/denote/pull/44>.
+
+  Also thanks to user pRot0ta1p for the relevant feedback in issue 43
+  (also on the mirror): <https://github.com/protesilaos/denote/issues/43>.
+  More thanks to Alfredo Borrás, Benjamin Kästner, and Sven Seebeck for
+  their comments in a related thread on the mailing list:
+  <https://lists.sr.ht/~protesilaos/denote/%3CCA73E705-1194-4324-9962-70708C4C72E5%40zoho.eu%3E>.
+  These discussions showed we had a problem, which we managed to
+  identify.
+
++ Introduced the user option ~denote-prompts~ (read its doc string or
+  the relevant entry in the manual).  It governs how the standard
+  ~denote~ command for creating new notes will behave in interactive
+  usage.  By default, ~denote~ prompts for a title and keywords.  With
+  ~denote-prompts~, the command can also ask for a file type (per
+  ~denote-file-type~), subdirectory of the ~denote-directory~, and a
+  specific date+time.  Prompts occur in the order they are specified.
+  Furthermore, the ~denote-prompts~ can be set to values which do not
+  include the title and keywords.  This means that the resulting file
+  names can be any of those permutations:
+
+  : DATE.EXT
+  : DATE--TITLE.EXT
+  : DATE__KEYWORDS.EXT
+
+  Recall that Denote's standard file-naming scheme is defined as follows
+  (read the manual for the details):
+
+  : DATE--TITLE__KEYWORDS.EXT
+
+  For our purposes, Denote will work perfectly fine for linking and
+  backlinking, even if file names do not include the =TITLE= and
+  =KEYWORDS= fields.  However, the user is advised to consider the
+  implications on usability: notes without a descriptive title and/or
+  useful keywords may be hard to filter and practically impossible to
+  manage at scale.  File names without such information should at least
+  be added to subdirectories which themselves have a descriptive name.
+
+  At any rate, Denote does not have strong opinions about one's
+  workflow.  The standard file name is the culmination of years of
+  experience.
+
+  Consider the ~denote-prompts~ the affirmative answer to the question
+  "Can keywords be optional?" as posed by Jack Baty on the mailing list:
+  <https://lists.sr.ht/~protesilaos/denote/%3C8D392BC3-980A-4E5B-9480-D6A00BE8279F%40baty.net%3E>.
+
+  Thanks to Jean-Philippe Gagné Guay for the original contribution in
+  commit 9b981a2.  It was originally part of a pull request, but due to
+  some internal changes I had to merge it as a patch and technically the
+  web UI did not count the PR as "merged" (though it was in terms of
+  substance).
+
++ Refactored the ~denote~ command to (i) accommodate the new user option
+  ~denote-prompts~ via its interactive specification and (ii) be more
+  flexible when called from Lisp.  The latter scenario is for advanced
+  users or, generally, those who can maintain some custom code in their
+  configuration.  A case in point is one of the examples we show in the
+  manual for a programmatic way to create notes that automatically get
+  the =journal= tag:
+
+  #+begin_src emacs-lisp
+  (defun my-denote-journal ()
+    "Create an entry tagged 'journal', while prompting for a title."
+    (interactive)
+    (denote
+     (denote--title-prompt)
+     '("journal")))
+  #+end_src
+
+  Notice that the ='("journal")= is a list of strings even for a single
+  keyword.  Whereas before a single one was a plain string.  This is a
+  breaking change.
+
+  Please consult the doc string of the ~denote~ command for the
+  technicalities.
+
++ Refashioned the interactive convenience functions of ~denote-type~,
+  ~denote-date~, ~denote-subdirectory~ to leverage the ~denote-prompts~
+  user option while calling ~denote~ interactively.  In practical terms,
+  they no longer accept any arguments when called from Lisp.  Users who
+  need a programmatic approach are advised to either call ~denote~
+  directly, or check how these commands ~let~ bind the ~denote-prompts~
+  to carry out their operations.  The doc string of each command
+  explains how it works.  Or evaluate this to check the manual:
+
+  #+begin_src emacs-lisp
+  (info "(denote) Convenience commands for note creation")
+  #+end_src
+
+  Else visit:
+  <https://protesilaos.com/emacs/denote#h:887bdced-9686-4e80-906f-789e407f2e8f>
+
++ Documented how the user option ~denote-directory~ can accept a local
+  value.  This is pertinent to scenaria where the user needs to maintain
+  separate directories of notes.  By "separate" we mean sets of notes
+  that do not communicate with each other, cannot create links between
+  them, etc.  The manual delves into the technicalities.  If you have
+  the Info entry installed, evaluate:
+
+  #+begin_src emacs-lisp
+  (info "(denote) Maintain separate directories for notes")
+  #+end_src
+
+  Else visit:
+  <https://protesilaos.com/emacs/denote#h:15719799-a5ff-4e9a-9f10-4ca03ef8f6c5>.
+
+  Thanks to user "Summer Emacs" for starting the discussion on the
+  mailing list, and Benjamin Kästner for their participation:
+  <https://lists.sr.ht/~protesilaos/denote/%3Cm25yk5e856.fsf@gmail.com%3E>.
+
++ Added an entry to the manual's Frequently Asked Questions about a
+  failed search for backlinks.  It includes sample code that users of
+  Windows can apply, if necessary.  (The error is not Denote's fault.)
+  Thanks to Benjamin Kästner for the patch, which is below the ~15 line
+  threshold and thus does not require copyright assignment to the Free
+  Software Foundation:
+  <https://lists.sr.ht/~protesilaos/denote/%3Cce117b14-55cf-622e-6cd8-0af698091ae3%40gmail.com%3E>.
+
++ Removed duplicate entries from the list of file paths that the =xref=
+  library returns for the purposes of backlinking.  Thanks to
+  Jean-Philippe Gagné Guay for the contribution in pull request 44 on
+  the GitHub mirror: <https://github.com/protesilaos/denote/issues/44>.
+
++ Applied an appropriate face to the backlinks' button to mitigate an
+  error.  Thanks to Jean-Philippe Gagné Guay for the contribution in
+  pull request 45 on the GitHub mirror and for later testing a
+  subsequent tweak: <https://github.com/protesilaos/denote/issues/45>.
+
++ Simplfied all the faces we define to make them work with all themes.
+  The previous colours were consistent with the =modus-themes=:
+  <https://protesilaos.com/emacs/modus-themes>.
+
++ Refined how strings are sluggified under all circumstances.  Before, a
+  nil value for the user option ~denote-allow-multi-word-keywords~ would
+  have the adverse effect of joining all the strings in the title field
+  of the file name.  The intent always was to do that only for
+  multi-word keywords, not the title.  This change was part of a hotfix,
+  formalised as version =0.2.1= a day after the release of =0.2.0=.
+
++ Made the fontification rules more robust, while avoiding any false
+  positives.  This was done over a series of commits as it had
+  implications for the file name permutations that were mentioned
+  earlier.  Thanks to Jean-Philippe Gagné Guay for the patches and/or
+  discussion about the merits of each change and concomitant
+  considerations:
+
+  - https://github.com/protesilaos/denote/pull/36
+  - https://github.com/protesilaos/denote/pull/38
+  - https://github.com/protesilaos/denote/pull/40
+  - https://github.com/protesilaos/denote/pull/42
+
++ Rewrote all relevant entries in the manual to reflect all the
+  user-facing aspects of the aforementioned.
+
++ Discussed a use-case of rewriting old journal entries as Denote-style
+  files.  As of this writing, we do not support migration of files in
+  bulk.  It might happen at some point, though it is no mean task.
+  Thanks to Summer Emacs and Alan Schmitt for their participation:
+  <https://lists.sr.ht/~protesilaos/denote/%3Cm27d4mbktj.fsf%40gmail.com%3E>.
+
+  An aside here as this topic was brought up: my packages are open to
+  users of all skill levels and is why I maintain a mailing list as well
+  as mirrors of the official git repository on SourceHut.  Do not
+  hesitate to ask a question.  If, for whatever reason, those
+  communication channels are not appropriate, you are welcome to contact
+  me in private: <https://protesilaos.com/contact>.
+
+Thanks again to Jean-Philippe Gagné Guay for the numerous contributions.
+Please read the commit log for the minutia, as this change log entry
+omitted some of the finer yet important details.
+
+* Version 0.2.0 on 2022-07-04
+:PROPERTIES:
+:CUSTOM_ID: h:2002fee6-3f0c-48be-9727-6d4e20f34856
+:END:
+
++ Version =0.1.0= (from 2022-06-27) was never built as a package.  The
+  reason is that the GNU ELPA machinery reads the =Version:= header of
+  the main file, not the git tag.  As the original commit in =denote.el=
+  included =Version: 0.1.0=, GNU ELPA rightly tries to build the package
+  using that reference.  But because at that time I had not yet updated
+  the Copyright header to name the Free Software Foundation, the package
+  could not be prepared.  As such, please consider this release to be
+  the "first formal stable version".  My apologies for the delay,
+  contrary to what was promised in the last change log entry.
+
+  - Prospective users are advised to read the manual:
+    <https://protesilaos.com/emacs/denote>.  For a video demonstration:
+    <https://protesilaos.com/codelog/2022-06-18-denote-demo/>.
+
+  - Thanks to Benjamin Kästner for reporting the issue with the GNU ELPA
+    package on the mailing list:
+    <https://lists.sr.ht/~protesilaos/denote/%3C9d600ff0-4fed-2ad7-5dbc-5a194639a045@gmail.com%3E>.
+
++ Originally, Denote was designed to only work with notes in a flat
+  directory.  With code contributions from Jean-Philippe Gagné Guay,
+  support for subdirectories of the user option ~denote-directory~ is
+  now available.  This covers the case of creating links between notes,
+  following them, and viewing the backlinks' buffer of the current
+  entry.
+
+  - Thanks to Jean-Philippe for the contributions which took place on
+    the GitHub mirror:
+
+    + <https://github.com/protesilaos/denote/pull/24>
+    + <https://github.com/protesilaos/denote/pull/25>
+    + <https://github.com/protesilaos/denote/pull/26>
+
+  - Jean-Philippe Gagné Guay has assigned copyright to the Free Software
+    Foundation.  This is a prerequisite to contribute code to any
+    package on the official GNU ELPA archive (and to emacs.git for that
+    matter).
+
++ The new ~denote-subdirectory~ command lets the user select a directory
+  to place the new note in.  Available candidates are the value of the
+  ~denote-directory~ as well as all of its subdirectories, minus =.git=.
+  In future versions, we will consider how to provide a blocklist or a
+  regexp filter for the user to specify which subdirectories should be
+  omitted from minibuffer completion.  Please consider providing your
+  feedback on the technicalities.
+
+  - Thanks to Jean-Philippe Gagné Guay and Shreyas Ragavan for the
+    feedback in issue 31 on the GitHub mirror:
+    <https://github.com/protesilaos/denote/issues/31>.
+
+  - Thanks to Jean-Philippe Gagné Guay for fixing a potential problem in
+    how directories are represented when commands enter the directory
+    instead of selecting it (again, at the GitHub mirror):
+    <https://github.com/protesilaos/denote/pull/35>.
+
++ From 2022-06-24 to 2022-07-03, Denote provided support for links
+  between Org notes that leveraged the =id:= hyperlink type.
+  Discussions on the mailing list and the GitHub mirror revealed the
+  longer-term problems in our implementation.  In the Annex below, I
+  provide my detailed opinion on the matter.  The gist is that Denote
+  does not---and will not---create =id:= links between its notes, but
+  shall use the =denote:= hyperlink type instead (which works like the
+  standard =file:= type).  As the Annex explains, Denote is not org-roam
+  lite and we try not to engender such false expectations.
+
+  - Despite the fact that the relevant patches are no longer applicable,
+    I wish to thank Kaushal Modi and Jean-Philippe Gagné Guay for their
+    contributions over at the GitHub mirror:
+
+    + <https://github.com/protesilaos/denote/pull/20>
+    + <https://github.com/protesilaos/denote/pull/28>
+
++ The user option ~denote-date-format~ controls how the date and time is
+  recorded in the file's contents (what we call "front matter").  When
+  nil (the default value), we use a file-type-specific format (also
+  check the user option ~denote-file-type~):
+
+  - For Org, an inactive timestamp is used, such as =[2022-06-30 Wed 15:31]=.
+
+  - For Markdown, the RFC3339 standard is applied: =2022-06-30T15:48:00+03:00=.
+
+  - For plain text, the format is that of ISO 8601: =2022-06-30=.
+
+  If the value is a string, ignore the above and use it instead.  The
+  string must include format specifiers for the date.  These are described
+  in the doc string of ~format-time-string~.
+
+  The ~denote-date-format~ supersedes the now obsolete
+  ~denote-front-matter-date-format~.
+
+  Thanks to Peter Prevos and Kaushal Modi for their feedback in issue 27
+  on the GitHub mirror: <https://github.com/protesilaos/denote/issues/27>.
+
++ All the faces we define are now declared in the =denote-faces.el=
+  file.  The fontification rules are shared by ~denote-dired-mode~ and
+  the backlinks' buffer (invoked by ~denote-link-backlinks~ and
+  controlled by the user option ~denote-link-fontify-backlinks~).  The
+  current list of faces:
+
+  - ~denote-faces-date~
+  - ~denote-faces-delimiter~
+  - ~denote-faces-extension~
+  - ~denote-faces-keywords~
+  - ~denote-faces-subdirectory~
+  - ~denote-faces-time~
+  - ~denote-faces-title~
+
++ Named the mailing list address as the =Maintainer:= of Denote.
+  Together with the other package headers, they help the user find our
+  primary sources and/or communication channels.  This change conforms
+  with work being done upstream in package.el by Philip Kaludercic.  I
+  was informed about it here:
+  <https://lists.sr.ht/~protesilaos/general-issues/%3C875ykl84yi.fsf%40posteo.net%3E>.
+
++ Fixed how keywords are inferred and combined.  The previous code did not
+  work properly when the user option =denote-infer-keywords= was nil.
+  It would return a list of symbols, with the parentheses, whereas the
+  file name needs a string where each keyword is delimited by an
+  underscore.
+
++ Simplified how information in the front matter is retrieved.  It fixes
+  cases where, for example, a special character at the end of the title
+  was ignored.  Thanks to Jean-Philippe Gagné Guay for the patch over at
+  the GitHub mirror: <https://github.com/protesilaos/denote/pull/21>.
+
++ Rewrote parts of the manual in the interest of clarity.
+
+** Annex about discontinuing support for org-id
+:PROPERTIES:
+:CUSTOM_ID: h:647d6155-1ac3-4ecb-bd4c-06d09fecd3ba
+:END:
+
+My thanks for their participation in the discussions go to Jean-Philippe
+Gagné Guay, Kaushal Modi, and Shreyas Ragavan.
+
+#+begin_example
+commit f35ef05cb451f265213c3aafc1e62c425b1ff043
+Author: Protesilaos Stavrou <info@protesilaos.com>
+Date:   Sun Jul 3 17:34:38 2022 +0300
+
+    REMOVE support for 'id:' hyperlink types
+
+    The original idea was to support the 'org-id' library on the premise
+    that it makes Denote a good Emacs citizen.  However, discussions on the
+    mailing list[0] and the GitHub mirror[1] have made it clear to me that
+    'org-id' is not consistent with Denote's emphasis on simplicity.
+
+    To support the way 'org-id' works, we will eventually have to develop
+    some caching mechanism, just how the org-roam package does it.  This is
+    because the variable 'org-id-extra-files' needs to be kept up-to-date
+    whenever an operation on a file is performed.  At scale, this sort of
+    monitoring requires specialised software.  Such a mechanism is outside
+    the scope of Denote---if you need a db, use org-roam which is already
+    great.
+
+    [0] <https://lists.sr.ht/~protesilaos/denote/%3C8735fk4y1w.fsf%40hallac.net%3E#%3C877d4un73c.fsf@protesilaos.com%3E>
+
+    [1] <https://github.com/protesilaos/denote/issues/29>
+
+    Quote of what I wrote on the GitHub mirror issue 29:
+
+            [ggjp] This is what I was implying.  That we are, in fact,
+            providing an option that is not viable long-term, but keeping
+            the option for expert users who will be able to handle this.
+            And we should warn about this clearly in the doc of that option.
+
+        [protesilaos] What you write here @ggjp and what @shrysr explained
+        tells me that those expert users will need to be real experts.  To
+        put it concretely, I am an experienced Emacs user with no
+        programming background, who has written several Emacs
+        packages (including the modus-themes which are built into Emacs),
+        but I have zero knowledge of using a db or of handling things with
+        python and the like.  So if I opt in to 'denote-link-use-org-id' I
+        will eventually run into problems that my non-existent skills will
+        prevent me from solving.  At that point, I will just use org-roam
+        which already handles this use-case in a competent way (and has a
+        massive community to rely on in case I need further support).
+
+        If each package needs to write its own optimisations and maintain
+        its own cache, to me this shows that 'org-id' is not good enough for
+        the time being: more work needs to be done in org.git to provide a
+        universal solution.
+
+        I wanted to support 'org-id' by default on the premise that Denote
+        must be a good Emacs citizen which interoperates with the rest of
+        the wider ecosystem.  But if 'org-id' leaves something to be
+        desired, then that goal is not worth pursuing: we add complexity to
+        our code, offer an option that we cannot genuinely/adequately
+        support, and make usage of it contingent on reading the docs and
+        having a high level of expertise.
+
+        I think being a good Emacs citizen is a laudable principle.  In this
+        case, the right thing to do is to recommend the use of org-roam
+        instead of trying to accommodate 'org-id'.  As such, I have now
+        changed my mind and think we should remove what we previously added.
+
+        For some context here: the reason I never used org-roam is
+        because (i) it is Org-specific whereas I write notes in different
+        file types and (ii) I did not want to ever rely on a db or
+        equivalent dependency.
+
+        <https://github.com/protesilaos/denote/issues/29#issuecomment-1173036924>
+
+ README.org         | 226 ++++++++---------------------------------------------
+ denote-link.el     |  99 ++++++-----------------
+ denote-retrieve.el |   2 +-
+ denote.el          |  14 +---
+ 4 files changed, 63 insertions(+), 278 deletions(-)
+#+end_example
+
+Followed up by my explanation:
+
+#+begin_src text
+> can we not have denote style links to be default for (de)notes - and
+> explicitly supported, while if they need to, users can still link
+> denote org files via org-id to any other notes/files (and vice versa)
+> -- in which case performance + testing for org-id driven linking is
+> not within Denote's purview at all?
+
+The formal support for `id:` links was added shortly before the release
+of version `0.1.0`.  In the days prior, we supported what you describe
+via the manual.  The user could change the `denote-org-front-matter`
+variable to include a `PROPERTIES` drawer.  This possibility still
+exists, though yesterday I removed the relevant entry from the manual.
+This way only the real do-it-yourself experts will go down that path.
+
+My concern here is with managing expectations.  If our Org notes are
+superficially the same as org-roam's, an unsuspecting user may think
+that Denote is an org-roam lite.  We will thus get issues/requests, such
+as those already mentioned in this GitHub repo, about migrating from
+org-roam to Denote.  While there are similarities, Denote is not a
+minimalist org-roam and I would not like to encourage the idea of
+treating the two as interchangeable.
+
+Doing things half-way-through is a way to create false expectations.  A
+package on GNU ELPA must be usable by users of all skill levels.  If the
+functionality we provide is incomplete and needs to be covered by
+user-level tweaks, we are excluding a portion of the user base while
+still assuming the maintenance burden.  If someone trusts Denote to,
+say, write a 1000 notes, we do not want to surprise them after the fact.
+Imagine if the reported issues that triggered this change happened 6
+months into one's daily usage of Denote: it wouldn't be nice.
+
+Setting the right expectations is a matter of responsibility: we let the
+user make a more informed choice and show respect for their time.  It
+also makes it easier for me to keep Denote's scope in check by not
+supporting every little extra that Org implements.  The premier Org
+extension is org-roam: we do not need another one (or, if we do, I am
+not the one to implement it).
+
+,* * *
+
+Some comments on the `denote:` hyperlink type for Org as they may be
+relevant in this context:
+
+,* It is meant to work like the standard `file:` type.  This means that
+  it links to a file, while it can also have additional search
+  parameters, as explained in the Org manual.  Evaluate:
+
+      (info "(org) Search Options")
+
+,* It does not read the front matter, but only the file name.  You can
+  create a note as usual, delete all its contents, save it, and try to
+  link to it from another note.  It works.
+
+,* Exporting now works like the `file:` type for HTML, LaTeX, Texinfo,
+  and Markdown.  Technically, it also supports the ASCII backend but the
+  format of the output could be tweaked further.
+
+There may be refinements to be made, which is okay as that is part of a
+maintainer's duties.
+#+end_src
+
+* Version 0.1.0 on 2022-06-27
+:PROPERTIES:
+:CUSTOM_ID: h:33939747-ad60-4913-a170-4b2f48f139cc
+:END:
+
+The present entry is intended for early adopters of Denote who may have
+not caught up with the latest developments.  Prospective users are
+advised to read the manual: <https://protesilaos.com/emacs/denote>.  For
+a video demonstration: <https://protesilaos.com/codelog/2022-06-18-denote-demo/>.
+
++ The =denote= package on GNU ELPA will be available a few hours after
+  this release.  GNU ELPA provides the latest stable release.  To use a
+  development snapshot, read:
+  <https://protesilaos.com/codelog/2022-05-13-emacs-elpa-devel/>.
+
++ Remember that any significant contribution (above ~15 lines) requires
+  copyright assignment to the Free Software Foundation.  A form with
+  instructions is included in the manual's "Contributing" section:
+  <https://protesilaos.com/emacs/denote#h:1ebe4865-c001-4747-a6f2-0fe45aad71cd>.
+
++ The front matter of notes in Org has changed to be compliant with the
+  standard =org-id= infrastructure.  A =PROPERTIES= drawer is added to
+  the top of the file, which includes an =ID= property with the value of
+  the Denote identifier.  Sample:
+
+  #+begin_src org
+  :PROPERTIES:
+  :ID:          20220610T202537
+  :END:
+  ,#+title:      Sample Org front matter
+  ,#+date:       2022-06-10
+  ,#+filetags:   denote  testing
+  #+end_src
+
++ The front matter of Markdown (YAML or TOML) and plain text files
+  remains constant.  For completeness, this is how they look:
+
+   #+begin_src md
+   ---
+   title:      "Sample with Markdown and YAML"
+   date:       2022-06-10
+   tags:       denote  testing
+   identifier: "20220610T202021"
+   ---
+   #+end_src
+
+  #+begin_src md
+  +++
+  title      = "Sample with Markdown and TOML"
+  date       = 2022-06-10
+  tags       = ["denote", "testing"]
+  identifier = "20220610T201510"
+  +++
+  #+end_src
+
+  #+begin_example
+  title:      Sample plain text
+  date:       2022-06-10
+  tags:       denote  testing
+  identifier: 20220610T202232
+  ---------------------------
+  #+end_example
+
++ The integration with =org-id= extends to how linking works.  By
+  default, Denote uses its own custom hyperlink type which starts with
+  the =denote:= prefix.  In Org, it works like the =file:= type.  When
+  the user option ~denote-link-use-org-id~ is non-nil, links from Org
+  notes to other Org notes will use the standard =id:= type instead.  As
+  this is an Org-specific feature, Denote takes care to use the
+  major-mode-agnostic =denote:= type when the link targets a non-Org
+  note.
+
++ In Org files the links created by Denote are buttonized automatically.
+  For Markdown and plain text, we use our own methods.  When a link is
+  inserted it is buttonized outright.  To buttonize links in existing
+  notes while visiting them in a buffer, add/evaluate this (it excludes
+  Org on its own):
+
+  #+begin_src emacs-lisp
+  (add-hook 'find-file-hook #'denote-link-buttonize-buffer)
+  #+end_src
+
++ The generation of the backlinks' buffer now uses the built-in =xref=
+  library instead of relying on a hardcoded call to the =find=
+  executable.  This means that the ~denote-link-backlinks~ command will,
+  in principle, work properly with all Emacs builds.
+
++ Users of Emacs 28 or higher can configure ~xref-search-program~ to
+  change from the default =grep= to =ripgrep=, =ugrep=, or a
+  user-defined alternative.
+
++ This is the first stable release of Denote.  It covers close to 400
+  commits starting from 2022-06-04.  Denote is the successor to a toy
+  package of mine, USLS, whose first public version was made available
+  in early November 2020: <https://gitlab.com/protesilaos/usls>.
+
++ Thanks to everyone involved in the development of Denote.  Code
+  contributions, bug reports, discussion of ideas, are all valuable.
+  From A-Z the names mentioned in the manual's "Acknowledgements"
+  section: Colin McLear, Damien Cassou, Frank Ehmsen, Jack Baty, Kaushal
+  Modi, Peter Povinec, Sven Seebeck, Ypot.
+
++ Sources of Denote:
+
+  + Package name (GNU ELPA): =denote=
+  + Official manual: <https://protesilaos.com/emacs/denote>
+  + Change log: <https://protesilaos.com/emacs/denote-changelog>
+  + Git repo on SourceHut: <https://git.sr.ht/~protesilaos/denote>
+    - Mirrors:
+      + GitHub: <https://github.com/protesilaos/denote>
+      + GitLab: <https://gitlab.com/protesilaos/denote>
+  + Mailing list: <https://lists.sr.ht/~protesilaos/denote>

--- a/vendor/denote-2.0.0/COPYING
+++ b/vendor/denote-2.0.0/COPYING
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2021  Protesilaos Stavrou
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) 2021  Protesilaos Stavrou
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/vendor/denote-2.0.0/README.md
+++ b/vendor/denote-2.0.0/README.md
@@ -1,0 +1,27 @@
+# denote: Simple notes with an efficient file-naming scheme
+
+Denote is a simple note-taking tool for Emacs.  It is based on the idea
+that notes should follow a predictable and descriptive file-naming
+scheme.  The file name must offer a clear indication of what the note is
+about, without reference to any other metadata.  Denote basically
+streamlines the creation of such files while providing facilities to
+link between them.
+
+Denote's file-naming scheme is not limited to "notes".  It can be used
+for all types of file, including those that are not editable in Emacs,
+such as videos.  Naming files in a constistent way makes their
+filtering and retrieval considerably easier.  Denote provides relevant
+facilities to rename files, regardless of file type.
+
++ Package name (GNU ELPA): `denote`
++ Official manual: <https://protesilaos.com/emacs/denote> (the manual is
+  installed with the package---evaluate `(info "(denote) Top")`)
++ Change log: <https://protesilaos.com/emacs/denote-changelog>
++ Git repo on SourceHut: <https://git.sr.ht/~protesilaos/denote>
+  - Mirrors:
+    + GitHub: <https://github.com/protesilaos/denote>
+    + GitLab: <https://gitlab.com/protesilaos/denote>
++ Mailing list: <https://lists.sr.ht/~protesilaos/denote>
++ Video demo: <https://protesilaos.com/codelog/2022-06-18-denote-demo/>
++ Backronyms: Denote Everything Neatly; Omit The Excesses.  Don't Ever
+  Note Only The Epiphenomenal.

--- a/vendor/denote-2.0.0/README.org
+++ b/vendor/denote-2.0.0/README.org
@@ -1,0 +1,4962 @@
+#+title:                 denote: Simple notes with an efficient file-naming scheme
+#+author:                Protesilaos Stavrou
+#+email:                 info@protesilaos.com
+#+language:              en
+#+options:               ':t toc:nil author:t email:t num:t
+#+startup:               content
+#+macro:                 stable-version 2.0.0
+#+macro:                 release-date 2023-07-21
+#+macro:                 development-version 2.1.0-dev
+#+export_file_name:      denote.texi
+#+texinfo_filename:      denote.info
+#+texinfo_dir_category:  Emacs misc features
+#+texinfo_dir_title:     Denote: (denote)
+#+texinfo_dir_desc:      Simple notes with an efficient file-naming scheme
+#+texinfo_header:        @set MAINTAINERSITE @uref{https://protesilaos.com,maintainer webpage}
+#+texinfo_header:        @set MAINTAINER Protesilaos Stavrou
+#+texinfo_header:        @set MAINTAINEREMAIL @email{info@protesilaos.com}
+#+texinfo_header:        @set MAINTAINERCONTACT @uref{mailto:info@protesilaos.com,contact the maintainer}
+
+#+texinfo: @insertcopying
+
+This manual, written by Protesilaos Stavrou, describes the customization
+options for the Emacs package called ~denote~ (or =denote.el=), and
+provides every other piece of information pertinent to it.
+
+The documentation furnished herein corresponds to stable version
+{{{stable-version}}}, released on {{{release-date}}}.  Any reference to
+a newer feature which does not yet form part of the latest tagged
+commit, is explicitly marked as such.
+
+Current development target is {{{development-version}}}.
+
++ Package name (GNU ELPA): ~denote~
++ Official manual: <https://protesilaos.com/emacs/denote>
++ Change log: <https://protesilaos.com/emacs/denote-changelog>
++ Git repo on SourceHut: <https://git.sr.ht/~protesilaos/denote>
+  - Mirrors:
+    + GitHub: <https://github.com/protesilaos/denote>
+    + GitLab: <https://gitlab.com/protesilaos/denote>
++ Mailing list: <https://lists.sr.ht/~protesilaos/denote>
++ Video demo: <https://protesilaos.com/codelog/2022-06-18-denote-demo/>
++ Backronyms: Denote Everything Neatly; Omit The Excesses.  Don't Ever
+  Note Only The Epiphenomenal.
+
+If you are viewing the README.org version of this file, please note that
+the GNU ELPA machinery automatically generates an Info manual out of it.
+
+#+toc: headlines 8 insert TOC here, with eight headline levels
+
+* COPYING
+:PROPERTIES:
+:COPYING: t
+:CUSTOM_ID: h:40b18bb2-4dc1-4202-bd0b-6fab535b2a0f
+:END:
+
+Copyright (C) 2022-2023  Free Software Foundation, Inc.
+
+#+begin_quote
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.3 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover Texts being “A GNU Manual,” and
+with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled “GNU Free Documentation License.”
+
+(a) The FSF’s Back-Cover Text is: “You have the freedom to copy and
+modify this GNU manual.”
+#+end_quote
+
+* Overview
+:PROPERTIES:
+:CUSTOM_ID: h:a09b70a2-ae0b-4855-ac14-1dddfc8e3241
+:END:
+
+Denote aims to be a simple-to-use, focused-in-scope, and effective
+note-taking and file-naming tool for Emacs.
+
+Denote is based on the idea that files should follow a predictable and
+descriptive file-naming scheme.  The file name must offer a clear
+indication of what the contents are about, without reference to any
+other metadata.  Denote basically streamlines the creation of such
+files or file names while providing facilities to link between them
+(where those files are editable).
+
+Denote's file-naming scheme is not limited to "notes".  It can be used
+for all types of file, including those that are not editable in Emacs,
+such as videos.  Naming files in a constistent way makes their
+filtering and retrieval considerably easier.  Denote provides relevant
+facilities to rename files, regardless of file type.
+
+Denote is based on the following core design principles:
+
++ Predictability :: File names must follow a consistent and descriptive
+  naming convention ([[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]]).  The file name alone
+  should offer a clear indication of what the contents are, without
+  reference to any other metadatum.  This convention is not specific to
+  note-taking, as it is pertinent to any form of file that is part of
+  the user's long-term storage ([[#h:532e8e2a-9b7d-41c0-8f4b-3c5cbb7d4dca][Renaming files]]).
+
++ Composability :: Be a good Emacs citizen, by integrating with other
+  packages or built-in functionality instead of re-inventing functions
+  such as for filtering or greping.  The author of Denote (Protesilaos,
+  aka "Prot") writes ordinary notes in plain text (=.txt=), switching on
+  demand to an Org file only when its expanded set of functionality is
+  required for the task at hand ([[#h:17896c8c-d97a-4faa-abf6-31df99746ca6][Points of entry]]).
+
++ Portability :: Notes are plain text and should remain portable.  The
+  way Denote writes file names, the front matter it includes in the
+  note's header, and the links it establishes must all be adequately
+  usable with standard Unix tools.  No need for a database or some
+  specialised software.  As Denote develops and this manual is fully
+  fleshed out, there will be concrete examples on how to do the
+  Denote-equivalent on the command-line.
+
++ Flexibility :: Do not assume the user's preference for a note-taking
+  methodology.  Denote is conceptually similar to the Zettelkasten
+  Method, which you can learn more about in this detailed introduction:
+  <https://zettelkasten.de/introduction/>.  Notes are atomic (one file
+  per note) and have a unique identifier.  However, Denote does not
+  enforce a particular methodology for knowledge management, such as a
+  restricted vocabulary or mutually exclusive sets of keywords.  Denote
+  also does not check if the user writes thematically atomic notes.  It
+  is up to the user to apply the requisite rigor and/or creativity in
+  pursuit of their preferred workflow ([[#h:6060a7e6-f179-4d42-a9de-a9968aaebecc][Writing metanotes]]).
+
++ Hackability :: Denote's code base consists of small and reusable
+  functions.  They all have documentation strings.  The idea is to make
+  it easier for users of varying levels of expertise to understand what
+  is going on and make surgical interventions where necessary (e.g. to
+  tweak some formatting).  In this manual, we provide concrete examples
+  on such user-level configurations ([[#h:4a6d92dd-19eb-4fcc-a7b5-05ce04da3a92][Keep a journal or diary]]).
+
+Now the important part...  "Denote" is the familiar word, though it also
+is a play on the "note" concept.  Plus, we can come up with acronyms,
+recursive or otherwise, of increasingly dubious utility like:
+
++ Don't Ever Note Only The Epiphenomenal
++ Denote Everything Neatly; Omit The Excesses
+
+But we'll let you get back to work.  Don't Eschew or Neglect your
+Obligations, Tasks, and Engagements.
+
+* Points of entry
+:PROPERTIES:
+:CUSTOM_ID: h:17896c8c-d97a-4faa-abf6-31df99746ca6
+:END:
+
+#+findex: denote
+#+findex: denote-type
+#+findex: denote-org-capture
+#+findex: denote-date
+#+findex: denote-subdirectory
+#+findex: denote-template
+#+findex: denote-signature
+There are five ways to write a note with Denote: invoke the ~denote~,
+~denote-type~, ~denote-date~, ~denote-subdirectory~,
+~denote-template~, ~denote-signature~ commands, or leverage the
+~org-capture-templates~ by setting up a template which calls the
+function ~denote-org-capture~.  We explain all of those in the
+subsequent sections.
+
+** Standard note creation
+:PROPERTIES:
+:CUSTOM_ID: h:6a92a8b5-d766-42cc-8e5b-8dc255466a23
+:END:
+
+The ~denote~ command will prompt for a title.  If a region is active,
+the text of the region becomes the default at the minibuffer prompt
+(meaning that typing =RET= without any input will use the default
+value).  Once the title is supplied, the ~denote~ command will then ask
+for keywords.  The resulting note will have a file name as already
+explained: [[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file naming scheme]]
+
+The file type of the new note is determined by the user option
+~denote-file-type~ ([[#h:13218826-56a5-482a-9b91-5b6de4f14261][Front matter]]).
+
+#+vindex: denote-known-keywords
+#+vindex: denote-infer-keywords
+The keywords' prompt supports minibuffer completion.  Available
+candidates are those defined in the user option ~denote-known-keywords~.
+More candidates can be inferred from the names of existing notes, by
+setting ~denote-infer-keywords~ to non-nil (which is the case by
+default).
+
+#+vindex: denote-sort-keywords
+Multiple keywords can be inserted by separating them with a comma (or
+whatever the value of the ~crm-separator~ is---which should be a comma).
+When the user option ~denote-sort-keywords~ is non-nil (the default),
+keywords are sorted alphabetically (technically, the sorting is done
+with ~string-lessp~).
+
+The interactive behaviour of the ~denote~ command is influenced by the
+user option ~denote-prompts~ ([[#h:f9204f1f-fcee-49b1-8081-16a08a338099][The denote-prompts option]]).
+
+The ~denote~ command can also be called from Lisp.  Read its doc string
+for the technicalities.
+
+#+findex: denote-create-note
+In the interest of discoverability, ~denote~ is also available under the
+alias ~denote-create-note~.
+
+*** The ~denote-prompts~ option
+:PROPERTIES:
+:CUSTOM_ID: h:f9204f1f-fcee-49b1-8081-16a08a338099
+:END:
+
+#+vindex: denote-prompts
+The user option ~denote-prompts~ determines how the ~denote~ command
+will behave interactively ([[#h:6a92a8b5-d766-42cc-8e5b-8dc255466a23][Standard note creation]]).
+
+The value is a list of symbols, which includes any of the following:
+
+- =title=: Prompt for the title of the new note.
+
+- =keywords=: Prompts with completion for the keywords of the new note.
+  Available candidates are those specified in the user option
+  ~denote-known-keywords~.  If the user option ~denote-infer-keywords~
+  is non-nil, keywords in existing note file names are included in the
+  list of candidates.  The =keywords= prompt uses
+  ~completing-read-multiple~, meaning that it can accept multiple
+  keywords separated by a comma (or whatever the value of ~crm-sepator~
+  is).
+
+- =file-type=: Prompts with completion for the file type of the new
+  note.  Available candidates are those specified in the user option
+  ~denote-file-type~.  Without this prompt, ~denote~ uses the value of
+  ~denote-file-type~.
+
+- =subdirectory=: Prompts with completion for a subdirectory in which to
+  create the note.  Available candidates are the value of the user
+  option ~denote-directory~ and all of its subdirectories.  Any
+  subdirectory must already exist: Denote will not create it.
+
+- =date=: Prompts for the date of the new note.  It will expect an input
+  like 2022-06-16 or a date plus time: 2022-06-16 14:30.  Without the
+  =date= prompt, the ~denote~ command uses the ~current-time~.
+
+  [[#h:e7ef08d6-af1b-4ab3-bb00-494a653e6d63][The denote-date-prompt-use-org-read-date option]].
+
+- =template=: Prompts for a KEY among the ~denote-templates~.  The value
+  of that KEY is used to populate the new note with content, which is
+  added after the front matter ([[#h:f635a490-d29e-4608-9372-7bd13b34d56c][The denote-templates option]]).
+
+- =signature=: - Prompts for an arbitrary string that can be used to
+  establish a sequential relationship between files (e.g. 1, 1a, 1b,
+  1b1, 1b2, ...).  Signatures have no strictly defined function and
+  are up to the user to apply as they see fit.  One use-case is to
+  implement Niklas Luhmann's Zettelkasten system for a sequence of
+  notes (Folgezettel).  Signatures are not included in a file's front
+  matter and are not shown in the description of a link.  They are
+  reserved solely for creating a sequence in a file listing, at least
+  for the time being.
+
+The prompts occur in the given order.
+
+If the value of this user option is nil, no prompts are used.  The
+resulting file name will consist of an identifier (i.e. the date and
+time) and a supported file type extension (per ~denote-file-type~).
+
+Recall that Denote's standard file-naming scheme is defined as follows
+([[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]]):
+
+: DATE--TITLE__KEYWORDS.EXT
+
+If either or both of the =title= and =keywords= prompts are not
+included in the value of this variable, file names will be any of
+those permutations:
+
+: DATE.EXT
+: DATE--TITLE.EXT
+: DATE__KEYWORDS.EXT
+
+When in doubt, always include the =title= and =keywords= prompts.
+
+Finally, this user option only affects the interactive use of the
+~denote~ command (advanced users can call it from Lisp).  For ad-hoc
+interactive actions that do not change the default behaviour of the
+~denote~ command, users can invoke these convenience commands:
+~denote-type~, ~denote-subdirectory~, ~denote-date~,
+~denote-signature~.  They are described in the subsequent section
+([[#h:887bdced-9686-4e80-906f-789e407f2e8f][Convenience commands for note creation]]).
+
+*** The ~denote-templates~ option
+:PROPERTIES:
+:CUSTOM_ID: h:f635a490-d29e-4608-9372-7bd13b34d56c
+:END:
+
+#+vindex: denote-templates
+The user option ~denote-templates~ is an alist of content templates for
+new notes.  A template is arbitrary text that Denote will add to a newly
+created note right below the front matter.
+
+Templates are expressed as a =(KEY . STRING)= association.
+
+- The =KEY= is the name which identifies the template.  It is an
+  arbitrary symbol, such as =report=, =memo=, =statement=.
+
+- The =STRING= is ordinary text that Denote will insert as-is.  It can
+  contain newline characters to add spacing.  Below we show some
+  concrete examples.
+
+The user can choose a template either by invoking the command
+~denote-template~ or by changing the user option ~denote-prompts~ to
+always prompt for a template when calling the ~denote~ command.
+
+[[#h:f9204f1f-fcee-49b1-8081-16a08a338099][The denote-prompts option]].
+
+[[#h:887bdced-9686-4e80-906f-789e407f2e8f][Convenience commands for note creation]].
+
+Templates can be written directly as one large string.  For example (the
+=\n= character is read as a newline):
+
+#+begin_src emacs-lisp
+(setq denote-templates
+      '((report . "* Some heading\n\n* Another heading")
+        (memo . "* Some heading
+
+,* Another heading
+
+")))
+#+end_src
+
+Long strings may be easier to type but interpret indentation literally.
+Also, they do not scale well.  A better way is to use some Elisp code to
+construct the string.  This would typically be the ~concat~ function,
+which joins multiple strings into one.  The following is the same as the
+previous example:
+
+#+begin_src emacs-lisp
+(setq denote-templates
+      `((report . "* Some heading\n\n* Another heading")
+        (memo . ,(concat "* Some heading"
+                         "\n\n"
+                         "* Another heading"
+                         "\n\n"))))
+#+end_src
+
+Notice that to evaluate a function inside of an alist we use the
+backtick to quote the alist (NOT the straight quote) and then prepend a
+comma to the expression that should be evaluated.  The ~concat~ form
+here is not sensitive to indentation, so it is easier to adjust for
+legibility.
+
+DEV NOTE: We do not provide more examples at this point, though feel
+welcome to ask for help if the information provided herein is not
+sufficient.  We shall expand the manual accordingly.
+
+*** Convenience commands for note creation
+:PROPERTIES:
+:CUSTOM_ID: h:887bdced-9686-4e80-906f-789e407f2e8f
+:END:
+
+Sometimes the user needs to create a note that has different
+requirements from those of ~denote~ ([[#h:6a92a8b5-d766-42cc-8e5b-8dc255466a23][Standard note creation]]).  While
+this can be achieved globally by changing the ~denote-prompts~ user
+option, there are cases where an ad-hoc method is the appropriate one
+([[#h:f9204f1f-fcee-49b1-8081-16a08a338099][The denote-prompts option]]).
+
+To this end, Denote provides the following convenience interactive
+commands for note creation:
+
++ Create note by specifying file type :: The ~denote-type~ command
+  creates a note while prompting for a file type.
+
+  This is the equivalent to calling ~denote~ when ~denote-prompts~ is
+  set to ='(file-type title keywords)=.  In practical terms, this lets
+  you produce, say, a note in Markdown even though you normally write in
+  Org ([[#h:6a92a8b5-d766-42cc-8e5b-8dc255466a23][Standard note creation]]).
+
+  #+findex: denote-create-note-using-type
+  The ~denote-create-note-using-type~ is an alias of ~denote-type~.
+
++ Create note using a date :: Normally, Denote reads the current date
+  and time to construct the unique identifier of a newly created note
+  ([[#h:6a92a8b5-d766-42cc-8e5b-8dc255466a23][Standard note creation]]).  Sometimes, however, the user needs to set
+  an explicit date+time value.
+
+  This is where the ~denote-date~ command comes in.  It creates a note
+  while prompting for a date.  The date can be in YEAR-MONTH-DAY
+  notation like =2022-06-30= or that plus the time: =2022-06-16 14:30=.
+
+  [[#h:e7ef08d6-af1b-4ab3-bb00-494a653e6d63][The denote-date-prompt-use-org-read-date option]].
+
+  This is the equivalent to calling ~denote~ when ~denote-prompts~ is
+  set to ='(date title keywords)=.
+
+  #+findex: denote-create-note-using-date
+  The ~denote-create-note-using-date~ is an alias of ~denote-date~.
+
++ Create note in a specific directory :: The ~denote-subdirectory~
+  command creates a note while prompting for a subdirectory.  Available
+  candidates include the value of the variable ~denote-directory~ and
+  any subdirectory thereof (Denote does not create subdirectories).
+
+  This is equivalent to calling ~denote~ when ~denote-prompts~ is set to
+  ='(subdirectory title keywords)=.
+
+  #+findex: denote-create-note-in-subdirectory
+  The ~denote-create-note-in-subdirectory~ is a more descriptive alias
+  of ~denote-subdirectory~.
+
++ Create note and add a template :: The ~denote-template~ command
+  creates a new note and inserts the specified template below the front
+  matter ([[#h:f635a490-d29e-4608-9372-7bd13b34d56c][The denote-templates option]]).  Available candidates for
+  templates are specified in the user option ~denote-templates~.
+
+  This is equivalent to calling ~denote~ when ~denote-prompts~ is
+  set to ='(template title keywords)=.
+
+  #+findex: denote-create-note-with-template
+  The ~denote-create-note-with-template~ is an alias of the command
+  ~denote-template~, meant to help with discoverability.
+
++ Create note with a signature :: The ~denote-signature~ command first
+  prompts for an arbitrary string to use in the optional =SIGNATURE=
+  field of the file name and then asks for a title and keywords.
+  Signatures are arbitrary strings of alphanumeric characters which
+  can be used to establish sequential relations between file at the
+  level of their file name (e.g. 1, 1a, 1b, 1b1, 1b2, ...).
+
+  The ~denote-create-note-using-signature~ is an alias of the command
+  ~denote-signature~ intended to make the functionality more
+  discoverable.
+
+**** Write your own convenience commands
+:PROPERTIES:
+:CUSTOM_ID: h:11946562-7eb0-4925-a3b5-92d75f1f5895
+:END:
+
+The convenience commands we provide only cover some basic use-cases
+([[#h:887bdced-9686-4e80-906f-789e407f2e8f][Convenience commands for note creation]]).  The user may require
+combinations that are not covered, such as to prompt for a template and
+for a subdirectory, instead of only one of the two.  To this end, we
+show how to follow the code we use in Denote to write your own variants
+of those commands.
+
+First let's take a look at the definition of one of those commands.
+They all look the same, but we use ~denote-subdirectory~ for this
+example:
+
+#+begin_src emacs-lisp
+(defun denote-subdirectory ()
+  "Create note while prompting for a subdirectory.
+
+Available candidates include the value of the variable
+`denote-directory' and any subdirectory thereof.
+
+This is equivalent to calling `denote' when `denote-prompts' is
+set to '(subdirectory title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(subdirectory title keywords)))
+    (call-interactively #'denote)))
+#+end_src
+
+The hyphenated word after ~defun~ is the name of the function.  It has
+to be unique.  Then we have the documentation string (or "doc string")
+which is for the user's convenience.
+
+This function is ~interactive~, meaning that it can be called via =M-x=
+or be assigned to a key binding.  Then we have the local binding of the
+~denote-prompts~ to the desired combination ("local" means specific to
+this function without affecting other contexts).  Lastly, it calls the
+standard ~denote~ command interactively, so it uses all the prompts in
+their specified order.
+
+Now let's say we want to have a command that (i) asks for a template and
+(ii) for a subdirectory ([[#h:f635a490-d29e-4608-9372-7bd13b34d56c][The denote-templates option]]).  All we need to
+do is tweak the ~let~ bound value of ~denote-prompts~ and give our
+command a unique name:
+
+#+begin_src emacs-lisp
+;; Like `denote-subdirectory' but also ask for a template
+(defun denote-subdirectory-with-template ()
+  "Create note while also prompting for a template and subdirectory.
+
+This is equivalent to calling `denote' when `denote-prompts' is
+set to '(template subdirectory title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(template subdirectory title keywords)))
+    (call-interactively #'denote)))
+#+end_src
+
+The tweaks to ~denote-prompts~ determine how the command will behave
+([[#h:f9204f1f-fcee-49b1-8081-16a08a338099][The denote-prompts option]]).  Use this paradigm to write your own
+variants which you can then assign to keys or invoke with =M-x=.
+
+*** The ~denote-date-prompt-use-org-read-date~ option
+:PROPERTIES:
+:CUSTOM_ID: h:e7ef08d6-af1b-4ab3-bb00-494a653e6d63
+:END:
+
+By default, Denote uses its own simple prompt for date or date+time
+input ([[#h:f9204f1f-fcee-49b1-8081-16a08a338099][The denote-prompts option]]).  This is done when the
+~denote-prompts~ option includes a =date= symbol and/or when the user
+invokes the ~denote-date~ command.
+
+#+vindex: denote-date-prompt-use-org-read-date
+Users who want to benefit from the more advanced date selection method
+that is common in interactions with Org mode, can set the user option
+~denote-date-prompt-use-org-read-date~ to a non-nil value.
+
+*** Add or remove keywords interactively
+:PROPERTIES:
+:CUSTOM_ID: h:ad4dde4a-8e88-470a-97ae-e7b9d4b41fb4
+:END:
+
+#+findex: denote-keywords-add
+#+findex: denote-keywords-remove
+The commands ~denote-keywords-add~ and ~denote-keywords-remove~
+streamline the process of interactively updating a file's keywords in
+the front matter and renaming it accordingly.
+
+The ~denote-keywords-add~ asks for keywords using the familiar
+minibuffer prompt ([[#h:6a92a8b5-d766-42cc-8e5b-8dc255466a23][Standard note creation]]).  It then renames the file
+([[#h:3ab08ff4-81fa-4d24-99cb-79f97c13a373][Rename a single file based on its front matter]]).
+
+Similarly, the ~denote-keywords-remove~ removes one or more keywords
+from the list of existing keywords and then renames the file
+accordingly.
+
+** Create note using Org capture
+:PROPERTIES:
+:CUSTOM_ID: h:656c70cd-cf9a-4471-a0b5-4f0aaf60f881
+:END:
+
+For integration with ~org-capture~, the user must first add the relevant
+template.  Such as:
+
+#+begin_src emacs-lisp
+(with-eval-after-load 'org-capture
+  (add-to-list 'org-capture-templates
+               '("n" "New note (with Denote)" plain
+                 (file denote-last-path)
+                 #'denote-org-capture
+                 :no-save t
+                 :immediate-finish nil
+                 :kill-buffer t
+                 :jump-to-captured t)))
+#+end_src
+
+[ In the future, we might develop Denote in ways which do not require such
+  manual intervention.  More user feedback is required to identify the
+  relevant workflows. ]
+
+Once the template is added, it is accessed from the specified key.  If,
+for instance, ~org-capture~ is bound to =C-c c=, then the note creation
+is initiated with =C-c c n=, per the above snippet.  After that, the
+process is the same as with invoking ~denote~ directly, namely: a prompt
+for a title followed by a prompt for keywords ([[#h:6a92a8b5-d766-42cc-8e5b-8dc255466a23][Standard note creation]]).
+
+#+vindex: denote-org-capture-specifiers
+Users may prefer to leverage ~org-capture~ in order to extend file
+creation with the specifiers described in the ~org-capture-templates~
+documentation (such as to capture the active region and/or create a
+hyperlink pointing to the given context).
+
+IMPORTANT.  Due to the particular file-naming scheme of Denote, which is
+derived dynamically, such specifiers or other arbitrary text cannot be
+written directly in the template.  Instead, they have to be assigned to
+the user option ~denote-org-capture-specifiers~, which is interpreted by
+the function ~denote-org-capture~.  Example with our default value:
+
+#+begin_src emacs-lisp
+(setq denote-org-capture-specifiers "%l\n%i\n%?")
+#+end_src
+
+Note that ~denote-org-capture~ ignores the ~denote-file-type~: it always
+sets the Org file extension for the created note to ensure that the
+capture process works as intended, especially for the desired output of
+the ~denote-org-capture-specifiers~.
+
+** Create note with specific prompts using Org capture
+:PROPERTIES:
+:CUSTOM_ID: h:95b78582-9086-47e8-967f-62373e2369a0
+:END:
+
+This section assumes knowledge of how Denote+org-capture work, as
+explained in the previous section ([[#h:656c70cd-cf9a-4471-a0b5-4f0aaf60f881][Create note using Org capture]]).
+
+#+findex: denote-org-capture-with-prompts
+The previous section shows how to define an Org capture template that
+always prompts for a title and keywords.  There are, however, cases
+where the user wants more control over what kind of input Denote will
+prompt for.  To this end, we provide the function
+~denote-org-capture-with-prompts~.  Below we explain it and then show
+some examples of how to use it.
+
+The ~denote-org-capture-with-prompts~ is like ~denote-org-capture~ but
+with optional prompt parameters.
+
+When called without arguments, it does not prompt for anything.  It
+just returns the front matter with title and keyword fields empty and
+the date and identifier fields specified.  It also makes the file name
+consist of only the identifier plus the Org file name extension.
+
+[[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]].
+
+Otherwise, it produces a minibuffer prompt for every non-nil value
+that corresponds to the =TITLE=, =KEYWORDS=, =SUBDIRECTORY=, =DATE=,
+and =TEMPLATE= arguments.  The prompts are those used by the standard
+~denote~ command and all of its utility commands.
+
+[[#h:17896c8c-d97a-4faa-abf6-31df99746ca6][Points of entry]].
+
+When returning the contents that fill in the Org capture template, the
+sequence is as follows: front matter, =TEMPLATE=, and then the value
+of the user option ~denote-org-capture-specifiers~.
+
+Important note: in the case of =SUBDIRECTORY= actual subdirectories
+must exist---Denote does not create them.  Same principle for
+=TEMPLATE= as templates must exist and are specified in the user
+option ~denote-templates~.
+
+This is how one can incorporate ~denote-org-capture-with-prompts~ in
+their Org capture templates.  Instead of passing a generic ~t~ which
+makes it hard to remember what the argument means, we use semantic
+keywords like =:title= for our convenience (internally this does not
+matter as the value still counts as non-nil, so =:foo= for =TITLE= is
+treated the same as =:title= or ~t~).
+
+#+begin_src emacs-lisp
+;; This prompts for TITLE, KEYWORDS, and SUBDIRECTORY
+(add-to-list 'org-capture-templates
+             '("N" "New note with prompts (with denote.el)" plain
+               (file denote-last-path)
+               (function
+                (lambda ()
+                  (denote-org-capture-with-prompts :title :keywords :subdirectory)))
+               :no-save t
+               :immediate-finish nil
+               :kill-buffer t
+               :jump-to-captured t))
+
+;; This prompts only for SUBDIRECTORY
+(add-to-list 'org-capture-templates
+             '("N" "New note with prompts (with denote.el)" plain
+               (file denote-last-path)
+               (function
+                (lambda ()
+                  (denote-org-capture-with-prompts nil nil :subdirectory)))
+               :no-save t
+               :immediate-finish nil
+               :kill-buffer t
+               :jump-to-captured t))
+
+;; This prompts for TITLE and SUBDIRECTORY
+(add-to-list 'org-capture-templates
+             '("N" "New note with prompts (with denote.el)" plain
+               (file denote-last-path)
+               (function
+                (lambda ()
+                  (denote-org-capture-with-prompts :title nil :subdirectory)))
+               :no-save t
+               :immediate-finish nil
+               :kill-buffer t
+               :jump-to-captured t))
+#+end_src
+
+** Maintain separate directory silos for notes
+:PROPERTIES:
+:CUSTOM_ID: h:15719799-a5ff-4e9a-9f10-4ca03ef8f6c5
+:END:
+#+cindex: Note silos
+
+The user option ~denote-directory~ accepts a value that represents the
+path to a directory, such as =~/Documents/notes=.  Normally, the user
+will have one place where they store all their notes, in which case this
+arrangement shall suffice.
+
+There is, however, the possibility to maintain separate directories of
+notes.  By "separate", we mean that they do not communicate with each
+other: no linking between them, no common keywords, nothing.  Think of
+the scenario where one set of notes is for private use and another is
+for an employer.  We call these separate directories "silos".
+
+To create silos, the user must specify a local variable at the root of
+the desired directory.  This is done by creating a =.dir-locals.el=
+file, with the following contents:
+
+#+begin_src emacs-lisp
+;;; Directory Local Variables.  For more information evaluate:
+;;;
+;;;     (info "(emacs) Directory Variables")
+
+((nil . ((denote-directory . default-directory))))
+#+end_src
+
+When inside the directory that contains this =.dir-locals.el= file, all
+Denote commands/functions for note creation, linking, the inference of
+available keywords, et cetera will use the silo as their point of
+reference.  They will not read the global value of ~denote-directory~.
+The global value of ~denote-directory~ is read everywhere else except
+the silos.
+
+[[#h:0f72e6ea-97f0-42e1-8fd4-0684af0422e0][Use custom commands to select a silo]].
+
+In concrete terms, this is a representation of the directory structures
+(notice the =.dir-locals.el= file is needed only for the silos):
+
+#+begin_example
+;; This is the global value of 'denote-directory' (no need for a .dir-locals.el)
+~/Documents/notes
+|-- 20210303T120534--this-is-a-test__journal_philosophy.txt
+|-- 20220303T120534--another-sample__journal_testing.md
+`-- 20220620T181255--the-third-test__keyword.org
+
+;; A silo with notes for the employer
+~/different/path/to/notes-for-employer
+|-- .dir-locals.el
+|-- 20210303T120534--this-is-a-test__conference.txt
+|-- 20220303T120534--another-sample__meeting.md
+`-- 20220620T181255--the-third-test__keyword.org
+
+;; Another silo with notes for my volunteering
+~/different/path/to/notes-for-volunteering
+|-- .dir-locals.el
+|-- 20210303T120534--this-is-a-test__activism.txt
+|-- 20220303T120534--another-sample__teambuilding.md
+`-- 20220620T181255--the-third-test__keyword.org
+#+end_example
+
+It is possible to configure other user options of Denote to have a
+silo-specific value.  For example, this one changes the
+~denote-known-keywords~ only for this particular silo:
+
+#+begin_src emacs-lisp
+;;; Directory Local Variables.  For more information evaluate:
+;;;
+;;;     (info "(emacs) Directory Variables")
+
+((nil . ((denote-directory . default-directory)
+         (denote-known-keywords . ("food" "drink")))))
+#+end_src
+
+This one is like the above, but also disables ~denote-infer-keywords~:
+
+#+begin_src emacs-lisp
+;;; Directory Local Variables.  For more information evaluate:
+;;;
+;;;     (info "(emacs) Directory Variables")
+
+((nil . ((denote-directory . default-directory)
+         (denote-known-keywords . ("food" "drink"))
+         (denote-infer-keywords . nil))))
+#+end_src
+
+To expand the list of local variables to, say, cover specific major
+modes, we can do something like this:
+
+#+begin_src emacs-lisp
+;;; Directory Local Variables.  For more information evaluate:
+;;;
+;;;     (info "(emacs) Directory Variables")
+
+((nil . ((denote-directory . default-directory)
+         (denote-known-keywords . ("food" "drink"))
+         (denote-infer-keywords . nil)))
+ (org-mode . ((org-hide-emphasis-markers . t)
+              (org-hide-macro-markers . t)
+              (org-hide-leading-stars . t))))
+#+end_src
+
+IMPORTANT If your silo contains sub-directories of notes, you
+should replace ~default-directory~ in the above examples with an
+absolute path to your silo directory, otherwise links from files
+within the sub-directories cannot be made to files in the parent
+directory. For example:
+
+#+begin_src emacs-lisp
+;;; Directory Local Variables.  For more information evaluate:
+;;;
+;;;     (info "(emacs) Directory Variables")
+  ((nil . ((denote-directory . "~/my-silo")
+           (denote-known-keywords . ("food" "drink"))
+           (denote-infer-keywords . nil)))
+   (org-mode . ((org-hide-emphasis-markers . t)
+                (org-hide-macro-markers . t)
+                (org-hide-leading-stars . t))))
+#+end_src
+
+As not all user options have a "safe" local value, Emacs will ask the
+user to confirm their choice and to store it in the Custom code
+snippet that is normally appended to init file (or added to the file
+specified by the user option ~custom-file~).
+
+Finally, it is possible to have a =.dir-locals.el= for subdirectories
+of any ~denote-directory~.  Perhaps to specify a different set of
+known keywords, while not making the subdirectory a silo in its own
+right.  We shall not expand on such an example, as we trust the user
+to experiment with the best setup for their workflow.
+
+Feel welcome to ask for help if the information provided herein is not
+sufficient.  The manual shall be expanded accordingly.
+
+*** Use custom commands to select a silo
+:PROPERTIES:
+:CUSTOM_ID: h:0f72e6ea-97f0-42e1-8fd4-0684af0422e0
+:END:
+
+We implement silos as directory-local values of the user option
+~denote-directory~.  This means that all Denote commands read from the
+local value if they are invoked from that context.  For example, if
+=~/Videos/recordings= is a silo and =~/Documents/notes= is the
+default/global value of ~denote-directory~ all Denote commands will
+read the video's path when called from there (e.g. by using Emacs'
+~dired~); any other context reads the global value.
+
+[[#h:15719799-a5ff-4e9a-9f10-4ca03ef8f6c5][Maintain separate directory silos for notes]].
+
+#+vindex: denote-user-enforced-denote-directory
+There are cases where the user (i) wants to maintain multiple silos
+and (ii) prefers an interactive way to switch between them without
+going through Dired.  Since this is specific to the user's workflow,
+it is easier to have some custom code for it.  The following should be
+added to the user's Denote configuration:
+
+#+begin_src emacs-lisp
+(defvar my-denote-silo-directories
+  `("/home/prot/Videos/recordings"
+    "/home/prot/Documents/books"
+    ;; You don't actually need to include the `denote-directory' here
+    ;; if you use the regular commands in their global context.  I am
+    ;; including it for completeness.
+    ,denote-directory)
+  "List of file paths pointing to my Denote silos.
+  This is a list of strings.")
+
+(defvar my-denote-commands-for-silos
+  '(denote
+    denote-date
+    denote-subdirectory
+    denote-template
+    denote-type)
+  "List of Denote commands to call after selecting a silo.
+  This is a list of symbols that specify the note-creating
+  interactive functions that Denote provides.")
+
+(defun my-denote-pick-silo-then-command (silo command)
+  "Select SILO and run Denote COMMAND in it.
+  SILO is a file path from `my-denote-silo-directories', while
+  COMMAND is one among `my-denote-commands-for-silos'."
+  (interactive
+   (list (completing-read "Select a silo: " my-denote-silo-directories nil t)
+         (intern (completing-read
+                  "Run command in silo: "
+                  my-denote-commands-for-silos nil t))))
+  (let ((denote-user-enforced-denote-directory silo))
+    (call-interactively command)))
+#+end_src
+
+With this in place, =M-x my-denote-pick-silo-then-command= will use
+minibuffer completion to select a silo among the predefined options
+and then ask for the command to run in that context.
+
+Note the use of the variable ~user-enforced-denote-directory~. This
+variable is specially meant for custom commands to select silos. When
+it is set, it overrides the global default value of ~denote-directory~
+as well as the value provided by the =.dir-locals.el= file. Use it
+only when writing wrapper functions like
+~my-denote-pick-silo-then-command~.
+
+To see another example of a wrapper function that uses
+~user-enforced-denote-directory~, see:
+
+[[#h:d0c7cb79-21e5-4176-a6af-f4f68578c8dd][Extending Denote: Split an Org subtree into its own note]].
+
+** Exclude certain directories from all operations
+:PROPERTIES:
+:CUSTOM_ID: h:8458f716-f9c2-4888-824b-2bf01cc5850a
+:END:
+
+#+vindex: denote-excluded-directories-regexp
+The user option ~denote-excluded-directories-regexp~ instructs all
+Denote functions that read or check file/directory names to omit
+directories that match the given regular expression.  The regexp needs
+to match only the name of the directory, not its full path.
+
+Affected operations include file prompts and functions that return the
+available files in the value of the user option ~denote-directory~
+([[#h:15719799-a5ff-4e9a-9f10-4ca03ef8f6c5][Maintain separate directory silos for notes]]).
+
+File prompts are used by several commands, such as ~denote-link~ and
+~denote-subdirectory~.
+
+Functions that check for files include ~denote-directory-files~ and
+~denote-directory-subdirectories~.
+
+The match is performed with ~string-match-p~.
+
+[[#h:c916d8c5-540a-409f-b780-6ccbd90e088e][For developers or advanced users]].
+
+** Exclude certain keywords from being inferred
+:PROPERTIES:
+:CUSTOM_ID: h:69e518ee-ed43-40ab-a5f4-c780a23e5358
+:END:
+
+#+vindex: denote-excluded-keywords-regexp
+The user option ~denote-excluded-keywords-regexp~ omits keywords that
+match a regular expression from the list of inferred keywords.
+
+Keywords are inferred from file names and provided at relevant prompts
+as completion candidates when the user option ~denote-infer-keywords~
+is non-nil.
+
+The match is performed with ~string-match-p~.
+
+** Use Denote commands from the menu bar or context menu
+:PROPERTIES:
+:CUSTOM_ID: h:c4290e15-e97e-4a9b-b8db-6b9738e37e78
+:END:
+
+Denote registers a submenu for the ~menu-bar-mode~.  Users will find
+the entry called "Denote".  From there they can use their pointer to
+select a command.  For a sample of how this looks, read the
+development log: <https://protesilaos.com/codelog/2023-03-31-emacs-denote-menu/>.
+
+Emacs also provides support for operations through a context menu.
+This is typically the set of actions that are made available via a
+right mouse click.  Users who enable ~context-menu-mode~ can register
+the Denote entry for it by adding the following to their configuration
+file:
+
+#+begin_src emacs-lisp
+(add-hook 'context-menu-functions #'denote-context-menu)
+#+end_src
+
+* Renaming files
+:PROPERTIES:
+:CUSTOM_ID: h:532e8e2a-9b7d-41c0-8f4b-3c5cbb7d4dca
+:END:
+
+Denote provides commands to rename files and update their front matter
+where relevant.  For Denote to work, only the file name needs to be in
+order, by following our naming conventions ([[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]]).
+The linking mechanism, in particular, needs just the identifier in the
+file name ([[#h:fc913d54-26c8-4c41-be86-999839e8ad31][Linking notes]]).
+
+We write front matter in notes for the user's convenience and for other
+tools to make use of that information (e.g. Org's export mechanism).
+The renaming mechanism takes care to keep this data in sync with the
+file name, when the user performs a change.
+
+Renaming is useful for managing existing files created with Denote,
+but also for converting older text files to Denote notes.  Denote's
+file-naming scheme is not specific to notes or text files: it is
+relevant for all sorts of items, such as multimedia and PDFs that form
+part of the user's longer-term storage.  While Denote does not manage
+such files (e.g. doesn't create links to them), it already has all the
+mechanisms to facilitate the task of renaming them.
+
+Apart from renaming files, Denote can also rename only the buffer.
+The idea is that the underlying file name is correct but it can be
+easier to use shorter buffer names when displaying them on the mode
+line or switching between then with commands like ~switch-to-buffer~.
+
+[[#h:3ca4db16-8f26-4d7d-b748-bac48ae32d69][Automatically rename Denote buffers]].
+
+** Rename a single file
+:PROPERTIES:
+:CUSTOM_ID: h:7cc9e000-806a-48da-945c-711bbc7426b0
+:END:
+
+#+findex: denote-rename-file
+The ~denote-rename-file~ command renames a file and updates existing
+front matter if appropriate.
+
+If in Dired, the =FILE= to be renamed is the one at point, else the
+command prompts with minibuffer completion for a target file.
+
+If =FILE= has a Denote-compliant identifier, retain it while updating
+the =TITLE= and =KEYWORDS= fields of the file name.  Else create an
+identifier based on the following conditions:
+
+- If =FILE= does not have an identifier and optional =DATE= is non-nil
+  (such as with a prefix argument), invoke the function
+  ~denote-prompt-for-date-return-id~.  It prompts for a date and uses
+  it to derive the identifier.
+
+- If =FILE= does not have an identifier and optional =DATE= is nil
+  (this is the case without a prefix argument), use the file
+  attributes to determine the last modified date and format it as an
+  identifier.
+
+- As a fallback, derive an identifier from the current time.
+
+- If the resulting identifier is not unique among the files in the
+  variable `denote-directory', increment it such that it becomes
+  unique.
+
+The default =TITLE= is retrieved from a line starting with a title field
+in the file's contents, depending on the given file type ([[#h:13218826-56a5-482a-9b91-5b6de4f14261][Front matter]]).
+Else, the file name is used as a default value at the minibuffer prompt.
+
+As a final step after the =FILE=, =TITLE=, and =KEYWORDS= prompts, ask
+for confirmation, showing the difference between old and new file names.
+For example:
+
+#+begin_example
+Rename sample.txt to 20220612T052900--my-sample-title__testing.txt? (y or n)
+#+end_example
+
+The file type extension (e.g. =.txt=) is read from the underlying file
+and is preserved through the renaming process.  Files that have no
+extension are simply left without one.
+
+Renaming only occurs relative to the current directory.  Files are not
+moved between directories.
+
+If the =FILE= has Denote-style front matter for the =TITLE= and
+=KEYWORDS=, this command asks to rewrite their values in order to
+reflect the new input (this step always requires confirmation and the
+underlying buffer is not saved, so consider invoking
+~diff-buffer-with-file~ to double-check the effect).  The rewrite of the
+=FILE= and =KEYWORDS= in the front matter should not affect the rest of
+the block.
+
+If the file doesn't have front matter but is among the supported file
+types (per ~denote-file-type~), the ~denote-rename-file~ command adds
+front matter at the top of it and leaves the buffer unsaved for further
+inspection.
+
+This command is intended to (i) rename existing Denote notes while
+updating their title and keywords in the front matter, (ii) convert
+existing supported file types to Denote notes, and (ii) rename non-note
+files (e.g. PDF) that can benefit from Denote's file-naming scheme.  The
+latter is a convenience we provide, since we already have all the
+requisite mechanisms in place (though Denote does not---and will
+not---manage such files).
+
+** Rename multiple files at once
+:PROPERTIES:
+:CUSTOM_ID: h:1b6b2c78-42f0-45b8-9ef0-6de21a8b2cde
+:END:
+
+#+findex: denote-dired-rename-marked-files
+The ~denote-dired-rename-marked-files~ command renames marked files in
+Dired to conform with our file-naming scheme.  Specifically, it does
+the following:
+
+- retains the file's existing name and make it the =TITLE= field, per
+  Denote's file-naming scheme;
+
+- downcases and sluggifies the =TITLE=, per our conventions;
+
+- prepends an identifier to the =TITLE=;
+
+- preserves the file's extension, if any;
+
+- prompts once for =KEYWORDS= and applies the user's input to the
+  corresponding field in the file name;
+
+- adds or rewrites existing front matter to the underlying file, if it
+  is recognized as a Denote note (per the ~denote-file-type~ user
+  option), such that it includes the new keywords.
+
+- prompts at the outset for a confirmation, unless optional
+  =SKIP-FRONT-MATTER-PROMPT= is non-nil (such as with a universal
+  prefix argument).
+
+  [ Note that the affected buffers are not saved.  Users can thus
+    check them to confirm that the new front matter does not cause any
+    problems (e.g. with the `diff-buffer-with-file' command).  Multiple
+    buffers can be saved in one go with `save-some-buffers' (read its
+    doc string). ]
+
+With the optional =NO-UNIQUE-ID-CHECK= as non-nil (such as as a double
+prefix argument), it does not process the file identifiers of the
+marked files for potential duplicates.  The default is to check for
+duplicates and increment them such that they become unique.  The
+reason this optional argument exists is for those who want to speed up
+the process, perhaps because they know ahead of time all identifiers
+will be unique or do not care about them.
+
+[ When renaming files in Dired, it is possible to produce duplicate
+  identifiers.  This can happen when multiple files share the same
+  modification time, which can be casually done with the `touch'
+  command, `git', and others. ]
+
+** Rename a single file based on its front matter
+:PROPERTIES:
+:CUSTOM_ID: h:3ab08ff4-81fa-4d24-99cb-79f97c13a373
+:END:
+
+#+findex: denote-rename-file-using-front-matter
+In the previous section, we covered the more general mechanism of the
+command ~denote-rename-file~ ([[#h:7cc9e000-806a-48da-945c-711bbc7426b0][Rename a single file]]).  There is also a
+way to have the same outcome by making Denote read the data in the
+current file's front matter and use it to construct/update the file
+name.  The command for this is ~denote-rename-file-using-front-matter~.
+It is only relevant for files that (i) are among the supported file
+types, per ~denote-file-type~, and (ii) have the requisite front matter
+in place.
+
+Suppose you have an =.org= file with this front matter ([[#h:13218826-56a5-482a-9b91-5b6de4f14261][Front matter]]):
+
+#+begin_example
+#+title:      My sample note file
+#+date:       [2022-08-05 Fri 13:10]
+#+filetags:   :testing:
+#+identifier: 20220805T131044
+#+end_example
+
+Its file name reflects this information:
+
+: 20220805T131044--my-sample-note-file__testing.org
+
+You want to change its title and keywords manually, so you modify it thus:
+
+#+begin_example
+#+title:      My modified sample note file
+#+date:       [2022-08-05 Fri 13:10]
+#+filetags:   :testing:denote:emacs:
+#+identifier: 20220805T131044
+#+end_example
+
+The file name still shows the old title and keywords.  So after saving
+the buffer, you invoke ~denote-rename-file-using-front-matter~ and it
+updates the file name to:
+
+: 20220805T131044--my-modified-sample-note-file__testing_denote_emacs.org
+
+The renaming is subject to a "yes or no" prompt that shows the old and
+new names, just so the user is certain about the change.
+
+If called interactively with a prefix argument =C-u= or from Lisp with
+a non-nil =AUTO-CONFIRM= argument, this "yes or no" prompt is skipped.
+
+The identifier of the file, if any, is never modified even if it is
+edited in the front matter: Denote considers the file name to be the
+source of truth in this case, to avoid potential breakage with typos and
+the like.
+
+** Rename multiple files based on their front matter
+:PROPERTIES:
+:CUSTOM_ID: h:ea5673cd-e6ca-4c42-a066-07dc6c9d57f8
+:END:
+
+#+findex: denote-dired-rename-marked-files-using-front-matter
+As already noted, Denote can rename a file based on the data in its
+front matter ([[#h:3ab08ff4-81fa-4d24-99cb-79f97c13a373][Rename a single file based on its front matter]]).  The
+command ~denote-dired-rename-marked-files-using-front-matter~ extends
+this principle to a batch operation which applies to all marked files in
+Dired.
+
+Marked files must count as notes for the purposes of Denote, which means
+that they at least have an identifier in their file name and use a
+supported file type, per ~denote-file-type~.  Files that do not meet
+this criterion are ignored.
+
+The operation does the following:
+
+- the title in the front matter becomes the =TITLE= component of the
+  file name ([[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]]);
+
+- the keywords in the front matter are used for the =KEYWORDS= component
+  of the file name and are processed accordingly, if needed;
+
+- the identifier remains unchanged in the file name even if it is
+  modified in the front matter (this is done to avoid breakage caused by
+  typos and the like).
+
+NOTE that files must be saved, because Denote reads from the underlying
+file, not a modified buffer (this is done to avoid potential mistakes).
+The return value of a modified buffer is the one prior to the
+modification, i.e. the one already written on disk.
+
+This command is useful for synchronizing multiple file names with their
+respective front matter.
+
+** Rename file by changing only its file type
+:PROPERTIES:
+:CUSTOM_ID: h:85b65995-89fd-4978-bba3-7bb6c8d6f945
+:END:
+
+#+findex: denote-change-file-type
+The command ~denote-change-file-type~ provides the convenience of
+converting a note taken in one file type, say, =.txt= into another
+like =.org=.  It presents a choice among the ~denote-file-type~
+options.
+
+The conversion does NOT modify the existing front matter.  Instead, it
+prepends new front matter to the top of the file.  We do this as a
+safety precaution since the user can, in principle, add arbitrary
+extras to their front matter that we would not want to touch.
+
+If in Dired, ~denote-change-file-type~ operates on the file at point,
+else it prompts with minibuffer completion for one.
+
+The title of the file is retrieved from a line starting with a title
+field in the file's front matter, depending on the previous file type
+(e.g.  =#+title= for Org).  The same process applies for keywords.
+
+As a final step, the command asks for confirmation, showing the
+difference between old and new file names.
+
+* The file-naming scheme
+:PROPERTIES:
+:CUSTOM_ID: h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d
+:END:
+
+#+vindex: denote-directory
+Notes are stored in the ~denote-directory~.  The default path is
+=~/Documents/notes=.  The ~denote-directory~ can be a flat listing,
+meaning that it has no subdirectories, or it can be a directory tree.
+Either way, Denote takes care to only consider "notes" as valid
+candidates in the relevant operations and will omit other files or
+directories.
+
+Every note produced by Denote follows this pattern by default
+([[#h:17896c8c-d97a-4faa-abf6-31df99746ca6][Points of entry]]):
+
+: DATE--TITLE__KEYWORDS.EXTENSION
+
+The =DATE= field represents the date in year-month-day format followed
+by the capital letter =T= (for "time") and the current time in
+hour-minute-second notation.  The presentation is compact:
+=20220531T091625=.  The =DATE= serves as the unique identifier of each
+note and, as such, is also known as the file's ID or identifier.
+
+The =TITLE= field is the title of the note, as provided by the user.  It
+automatically gets downcased and hyphenated.  An entry about "Economics
+in the Euro Area" produces an =economics-in-the-euro-area= string for
+the =TITLE= of the file name.
+
+The =KEYWORDS= field consists of one or more entries demarcated by an
+underscore (the separator is inserted automatically).  Each keyword is
+a string provided by the user at the relevant prompt which broadly
+describes the contents of the entry.
+
+#+vindex: denote-allow-multi-word-keywords
+Optionally, when the user option ~denote-allow-multi-word-keywords~ is
+non-nil, keywords that need to be more than one-word-long are written
+with hyphens: any other character, such as spaces or the plus sign is
+automatically converted into a hyphen.  So when =emacs_library=
+appears in a file name, it is interpreted as two distinct keywords,
+whereas =emacs-library= is one keyword.  This is reflected in how the
+keywords are recorded in the note ([[#h:13218826-56a5-482a-9b91-5b6de4f14261][Front matter]]).  While Denote
+optional supports multi-word keywords, default ~nil~ value of
+~denote-allow-multi-word-keywords~ forcibly joins all words into one,
+meaning that an input of =word1 word2= will be written as
+=word1word2=.
+
+#+vindex: denote-file-type
+The =EXTENSION= is the file type.  By default, it is =.org= (~org-mode~)
+though the user option ~denote-file-type~ provides support for Markdown
+with YAML or TOML variants (=.md= which runs ~markdown-mode~) and plain
+text (=.txt= via ~text-mode~).  Consult its doc string for the minutiae.
+While files end in the =.org= extension by default, the Denote code base
+does not actually depend on org.el and/or its accoutrements.
+
+Examples:
+
+: 20220610T043241--initial-thoughts-on-the-zettelkasten-method__notetaking.org
+: 20220610T062201--define-custom-org-hyperlink-type__denote_emacs_package.md
+: 20220610T162327--on-hierarchy-and-taxis__notetaking_philosophy.txt
+
+The different field separators, namely =--= and =__= introduce an
+efficient way to anchor searches (such as with Emacs commands like
+~isearch~ or from the command-line with ~find~ and related).  A query
+for =_word= always matches a keyword, while a regexp in the form of,
+say, ="\\([0-9T]+?\\)--\\(.*?\\)_"= captures the date in group =\1= and
+the title in =\2= (test any regular expression in the current buffer by
+invoking =M-x re-builder=).
+
+[[#h:1a953736-86c2-420b-b566-fb22c97df197][Features of the file-naming scheme for searching or filtering]].
+
+As an optional extension to the above, file names can include a string
+of alphanumeric characters in the =SIGNATURE= field.  Signatures have
+no clearly defined purpose and are up to the user to define.  One
+use-case is to use them to establish sequential relations between
+files (e.g. 1, 1a, 1b, 1b1, 1b2, ...).  A full file name with a
+signature looks like this:
+
+: DATE==SIGNATURE--TITLE__KEYWORDS.EXTENSION
+
+The =SIGNATURE= field is anchored by the equals sign and thus retains
+the aforementioned searching/anchoring feature of =--= and =__=.
+
+Signatures are an optional extension to Denote's file-naming scheme.
+They can be added to newly created files on demand, with the command
+~denote-signature~, or by modifying the value of the user option
+~denote-prompts~.
+
+The ~denote-prompts~ can be configured in such ways to yield the
+following file name permutations:
+
+: DATE.EXT
+: DATE--TITLE.EXT
+: DATE__KEYWORDS.EXT
+: DATE==SIGNATURE.EXT
+: DATE==SIGNATURE--TITLE.EXT
+: DATE==SIGNATURE--TITLE__KEYWORDS.EXT
+: DATE==SIGNATURE__KEYWORDS.EXT
+
+When in doubt, stick to the default design.
+
+While Denote is an Emacs package, notes should work long-term and not
+depend on the functionality of a specific program.  The file-naming
+scheme we apply guarantees that a listing is readable in a variety of
+contexts.  The Denote file-naming scheme is, in essence, an effective,
+low-tech invention.
+
+** Sluggified title, keywords, and signature
+:PROPERTIES:
+:CUSTOM_ID: h:ae8b19a1-7f67-4258-96b3-370a72c43f4e
+:END:
+
+Denote has to be highly opinionated about which characters can be used
+in file names and the file's front matter in order to enforce its
+file-naming scheme.  The variable ~denote-excluded-punctuation-regexp~
+holds the relevant value.  In simple terms:
+
++ What we count as "illegal characters" are converted into hyphens.
+
++ Input for a file title is hyphenated and downcased.  The original
+  value is preserved in the note's contents ([[#h:13218826-56a5-482a-9b91-5b6de4f14261][Front matter]]).
+
++ Keywords should not have spaces or other delimiters.  If they do, they
+  are converted into hyphens.  Keywords are always downcased.
+
++ Signatures are like the above, but use the equals sign instead of
+  hyphens.
+
+** Features of the file-naming scheme for searching or filtering
+:PROPERTIES:
+:CUSTOM_ID: h:1a953736-86c2-420b-b566-fb22c97df197
+:END:
+
+By default, file names have three fields and two sets of field
+delimiters between them:
+
+: DATE--TITLE__KEYWORDS.EXTENSION
+
+When a signature is present, this becomes:
+
+: DATE==SIGNATURE--TITLE__KEYWORDS.EXTENSION
+
+Field delimiters practically serve as anchors for easier searching.
+Consider this example:
+
+: 20220621T062327==1a2--introduction-to-denote__denote_emacs.txt
+
+You will notice that there are two matches for the word =denote=: one
+in the title field and another in the keywords' field.  Because of the
+distinct field delimiters, if we search for =-denote= we only match
+the first instance while =_denote= targets the second one.  When
+sorting through your notes, this kind of specificity is
+invaluable---and you get it for free from the file names alone!
+Similarly, a search for ==1= will show all notes that are related to
+each other by virtue of their signature.
+
+Users can get a lot of value out of this simple yet effective
+arrangement, even if they have no knowledge of regular expressions.
+One thing to consider, for maximum effect, is to avoid using
+multi-word keywords as those can get hyphenated like the title and
+will thus interfere with the above: either set the user option
+~denote-allow-multi-word-keywords~ to nil or simply insert single
+words at the relevant prompts.
+
+* Front matter
+:PROPERTIES:
+:CUSTOM_ID: h:13218826-56a5-482a-9b91-5b6de4f14261
+:END:
+
+Notes have their own "front matter".  This is a block of data at the top
+of the file, with no empty lines between the entries, which is
+automatically generated at the creation of a new note.  The front matter
+includes the title and keywords (aka "tags" or "filetags", depending on
+the file type) which the user specified at the relevant prompt, as well
+as the date and unique identifier, which are derived automatically.
+
+This is how it looks for Org mode (when ~denote-file-type~ is nil or the
+=org= symbol):
+
+#+begin_example
+#+title:      This is a sample note
+#+date:       [2022-06-30 Thu 16:09]
+#+filetags:   :denote:testing:
+#+identifier: 20220630T160934
+#+end_example
+
+For Markdown with YAML (~denote-file-type~ has the =markdown-yaml=
+value), the front matter looks like this:
+
+#+begin_example
+---
+title:      "This is a sample note"
+date:       2022-06-30T16:09:58+03:00
+tags:       ["denote", "testing"]
+identifier: "20220630T160958"
+---
+#+end_example
+
+For Markdown with TOML (~denote-file-type~ has the =markdown-toml=
+value), it is:
+
+#+begin_example
++++
+title      = "This is a sample note"
+date       = 2022-06-30T16:10:13+03:00
+tags       = ["denote", "testing"]
+identifier = "20220630T161013"
++++
+#+end_example
+
+And for plain text (~denote-file-type~ has the =text= value), we have
+the following:
+
+#+begin_example
+title:      This is a sample note
+date:       2022-06-30
+tags:       denote  testing
+identifier: 20220630T161028
+---------------------------
+#+end_example
+
+#+vindex: denote-date-format
+The format of the date in the front matter is controlled by the user
+option ~denote-date-format~.  When nil, Denote uses a file-type-specific
+format:
+
+- For Org, an inactive timestamp is used, such as
+  =[2022-06-30 Wed 15:31]=.
+
+- For Markdown, the RFC3339 standard is applied:
+  =2022-06-30T15:48:00+03:00=.
+
+- For plain text, the format is that of ISO 8601: =2022-06-30=.
+
+If the value is a string, ignore the above and use it instead.  The
+string must include format specifiers for the date.  These are described
+in the doc string of ~format-time-string~..
+
+** Change the front matter format
+:PROPERTIES:
+:CUSTOM_ID: h:7f918854-5ed4-4139-821f-8ee9ba06ad15
+:END:
+
+Per Denote's design principles, the code is hackable.  All front matter
+is stored in variables that are intended for public use.  We do not
+declare those as "user options" because (i) they expect the user to have
+some degree of knowledge in Emacs Lisp and (ii) implement custom code.
+
+[ NOTE for tinkerers: code intended for internal use includes double
+  hyphens in its symbol.  "Internal use" means that it can be changed
+  without warning and with no further reference in the change log.  Do
+  not use any of it without understanding the consequences. ]
+
+The variables which hold the front matter format are:
+
+#+vindex: denote-org-front-matter
+- ~denote-org-front-matter~
+
+#+vindex: denote-text-front-matter
+- ~denote-text-front-matter~
+
+#+vindex: denote-toml-front-matter
+- ~denote-toml-front-matter~
+
+#+vindex: denote-yaml-front-matter
+- ~denote-yaml-front-matter~
+
+These variables have a string value with specifiers that are used by the
+~format~ function.  The formatting operation passes four arguments which
+include the values of the given entries.  If you are an advanced user
+who wants to edit this variable to affect how front matter is produced,
+consider using something like =%2$s= to control where the Nth argument
+is placed.
+
+When editing the value, make sure to:
+
+1. Not use empty lines inside the front matter block.
+
+2. Insert at least one empty line after the front matter block and do
+   not use any empty line before it.
+
+These help with consistency and might prove useful if we ever need to
+operate on the front matter as a whole.
+
+With those granted, below are some examples.  The approach is the same
+for all variables.
+
+#+begin_src emacs-lisp
+;; Like the default, but upcase the entries
+(setq denote-org-front-matter
+  "#+TITLE:      %s
+#+DATE:       %s
+#+FILETAGS:   %s
+#+IDENTIFIER: %s
+\n")
+
+;; Change the order (notice the %N$s notation)
+(setq denote-org-front-matter
+  "#+title:      %1$s
+#+filetags:   %3$s
+#+date:       %2$s
+#+identifier: %4$s
+\n")
+
+;; Remove the date
+(setq denote-org-front-matter
+  "#+title:      %1$s
+#+filetags:   %3$s
+#+identifier: %4$s
+\n")
+
+;; Remove the date and the identifier
+(setq denote-org-front-matter
+  "#+title:      %1$s
+#+filetags:   %3$s
+\n")
+#+end_src
+
+Note that ~setq~ has a global effect: it affects the creation of all new
+notes.  Depending on the workflow, it may be preferrable to have a
+custom command which ~let~ binds the different format.  We shall not
+provide examples at this point as this is a more advanced feature and we
+are not yet sure what the user's needs are.  Please provide feedback and
+we shall act accordingly.
+
+** Regenerate front matter
+:PROPERTIES:
+:CUSTOM_ID: h:54b48277-e0e5-4188-ad54-ef3db3b7e772
+:END:
+
+#+findex: denote-add-front-matter
+Sometimes the user needs to produce new front matter for an existing
+note.  Perhaps because they accidentally deleted a line and could not
+undo the operation.  The command ~denote-add-front-matter~ can be used
+for this very purpose.
+
+In interactive use, ~denote-add-front-matter~ must be invoked from a
+buffer that visits a Denote note.  It prompts for a title and then for
+keywords.  These are the standard prompts we already use for note
+creation, so the keywords' prompt allows minibuffer completion and the
+input of multiple entries, each separated by a comma ([[#h:17896c8c-d97a-4faa-abf6-31df99746ca6][Points of entry]]).
+
+The newly created front matter is added to the top of the file.
+
+This command does not rename the file (e.g. to update the keywords).  To
+rename a file by reading its front matter as input, the user can rely on
+~denote-rename-file-using-front-matter~ ([[#h:532e8e2a-9b7d-41c0-8f4b-3c5cbb7d4dca][Renaming files]]).
+
+Note that ~denote-add-front-matter~ is useful only for existing Denote
+notes.  If the user needs to convert a generic text file to a Denote
+note, they can use one of the command which first rename the file to
+make it comply with our file-naming scheme and then add the relevant
+front matter.
+
+* Linking notes
+:PROPERTIES:
+:CUSTOM_ID: h:fc913d54-26c8-4c41-be86-999839e8ad31
+:END:
+
+Denote offers several commands for linking between notes.
+
+All links target files which are Denote notes.  This means that they
+have our file-naming scheme, are writable/regular (not directory, named
+pipe, etc.), and use the appropriate file type extension (per
+~denote-file-type~).  Furthermore, the files need to be inside the
+~denote-directory~ or one of its subdirectories.  No other file is
+recognised.
+
+The following sections delve into the details.
+
+** Adding a single link
+:PROPERTIES:
+:CUSTOM_ID: h:5e5e3370-12ab-454f-ba09-88ff44214324
+:END:
+
+#+findex: denote-link
+The ~denote-link~ command inserts a link at point to an entry specified
+at the minibuffer prompt.  Links are formatted depending on the file
+type of current note.  In Org and plain text buffers, links are
+formatted thus: =[[denote:IDENTIFIER][TITLE]]=.  While in Markdown they
+are expressed as =[TITLE](denote:IDENTIFIER)=.
+
+When ~denote-link~ is called with a prefix argument (=C-u= by default),
+it formats links like =[[denote:IDENTIFIER]]=.  The user might prefer
+its simplicity.
+
+The description of the link is taken from the target file's front
+matter or, if that is not available, from the file name.  If the
+region is active, its text is used as the link's description instead.
+If the active region has no text, the inserted link used just the
+identifier, as with the =C-u= prefix mentioned above.
+
+Inserted links are automatically buttonized and remain active for as
+long as the buffer is available.  In Org this is handled by the major
+mode: the =denote:= hyperlink type works exactly like the standard
+=file:=.  In Markdown and plain text, Denote performs the buttonization
+of those links.  To buttonize links in existing files while visiting
+them, the user must add this snippet to their setup (it already excludes
+Org):
+
+#+findex: denote-link-buttonize-buffer
+#+begin_src emacs-lisp
+(add-hook 'find-file-hook #'denote-link-buttonize-buffer)
+#+end_src
+
+The ~denote-link-buttonize-buffer~ is also an interactive function in
+case the user needs it.
+
+Links are created only for files which qualify as a "note" for our
+purposes ([[#h:fc913d54-26c8-4c41-be86-999839e8ad31][Linking notes]]).
+
+#+vindex: denote-faces-link
+Links are styled with the ~denote-faces-link~ face, which looks exactly
+like an ordinary link by default.  This is just a convenience for the
+user/theme in case they want =denote:= links to remain distinct from
+other links.
+
+** Insert links matching a regexp
+:PROPERTIES:
+:CUSTOM_ID: h:9bec2c83-36ca-4951-aefc-7187c5463f90
+:END:
+
+#+findex: denote-add-links
+The command ~denote-add-links~ adds links at point matching a
+regular expression or plain string.  The links are inserted as a
+typographic list, such as:
+
+#+begin_example
+- link1
+- link2
+- link3
+#+end_example
+
+Each link is formatted according to the file type of the current note,
+as explained further above about the ~denote-link~ command.  The current
+note is excluded from the matching entries (adding a link to itself is
+pointless).
+
+When called with a prefix argument (=C-u=) ~denote-add-links~ will
+format all links as =[[denote:IDENTIFIER]]=, hence a typographic list:
+
+#+begin_example
+- [[denote:IDENTIFIER-1]]
+- [[denote:IDENTIFIER-2]]
+- [[denote:IDENTIFIER-3]]
+#+end_example
+
+Same examples of a regular expression that can be used with this
+command:
+
+- =journal= match all files which include =journal= anywhere in their
+  name.
+
+- =_journal= match all files which include =journal= as a keyword.
+
+- =^2022.*_journal= match all file names starting with =2022= and
+  including the keyword =journal=.
+
+- =\.txt= match all files including =.txt=.  In practical terms, this
+  only applies to the file extension, as Denote automatically removes
+  dots (and other characters) from the base file name.
+
+If files are created with ~denote-sort-keywords~ as non-nil (the
+default), then it is easy to write a regexp that includes multiple
+keywords in alphabetic order:
+
+- =_denote.*_package= match all files that include both the =denote= and
+  =package= keywords, in this order.
+
+- =\(.*denote.*package.*\)\|\(.*package.*denote.*\)= is the same as
+  above, but out-of-order.
+
+Remember that regexp constructs only need to be escaped once (like =\|=)
+when done interactively but twice when called from Lisp.  What we show
+above is for interactive usage.
+
+Links are created only for files which qualify as a "note" for our
+purposes ([[#h:fc913d54-26c8-4c41-be86-999839e8ad31][Linking notes]]).
+
+** Insert links, but only those missing from current buffer
+:PROPERTIES:
+:CUSTOM_ID: h:0c1fdaab-5a6b-4792-9694-fed53cd042e6
+:END:
+
+#+findex: denote-add-missing-links
+As a variation on the ~denote-add-links~ command, one may wish to only
+include 'missing links', i.e. links that are not yet present in the
+current file.
+
+This can be achieved with ~denote-add-missing-links~. The command is
+similar to ~denote-add-links~, but will only include links to notes
+that are not yet linked to ([[#h:9bec2c83-36ca-4951-aefc-7187c5463f90][Insert links matching a regexp]]).
+
+** Insert links from marked files in Dired
+:PROPERTIES:
+:CUSTOM_ID: h:9cbb692e-5d8a-44a6-9193-899a07872a07
+:END:
+
+#+findex: denote-link-dired-marked-notes
+The command ~denote-link-dired-marked-notes~ is similar to
+~denote-add-links~ in that it inserts in the buffer a typographic list
+of links to Denote notes ([[#h:9bec2c83-36ca-4951-aefc-7187c5463f90][Insert links matching a regexp]]).  Though
+instead of reading a regular expression, it lets the user mark files
+in Dired and link to them.  This should be easier for users of all
+skill levels, instead of having to write a potentially complex regular
+expression.
+
+If there are multiple buffers that visit a Denote note, this command
+will ask to select one among them, using minibuffer completion.  If
+there is only one buffer, it will operate in it outright.  If there are
+no buffers, it will produce an error.
+
+With optional =ID-ONLY= as a prefix argument (=C-u= by default), the
+command inserts links with just the identifier, which is the same
+principle as with ~denote-link~ and others ([[#h:5e5e3370-12ab-454f-ba09-88ff44214324][Adding a single link]]).
+
+The command ~denote-link-dired-marked-notes~ is meant to be used from a
+Dired buffer.
+
+As always, links are created only for files which qualify as a "note"
+for our purposes ([[#h:fc913d54-26c8-4c41-be86-999839e8ad31][Linking notes]]).
+
+** Link to an existing note or create a new one
+:PROPERTIES:
+:CUSTOM_ID: h:9e41e7df-2aac-4835-94c5-659b6111e6de
+:END:
+
+In one's note-taking workflow, there may come a point where they are
+expounding on a certain topic but have an idea about another subject
+they would like to link to ([[#h:fc913d54-26c8-4c41-be86-999839e8ad31][Linking notes]]).  The user can always rely on
+the other linking facilities we have covered herein to target files that
+already exist.  Though they may not know whether they already have notes
+covering the subject or whether they would need to write new ones.  To
+this end, Denote provides two convenience commands:
+
+#+findex: denote-link-after-creating
++ ~denote-link-after-creating~ :: Create new note in the background and
+  link to it directly.
+
+  Use ~denote~ interactively to produce the new note.  Its doc string or
+  this manual explains which prompts will be used and under what
+  conditions ([[#h:6a92a8b5-d766-42cc-8e5b-8dc255466a23][Standard note creation]]).
+
+  With optional =ID-ONLY= as a prefix argument (this is the =C-u= key,
+  by default) create a link that consists of just the identifier.  Else
+  try to also include the file's title.  This has the same meaning as in
+  ~denote-link~ ([[#h:5e5e3370-12ab-454f-ba09-88ff44214324][Adding a single link]]).
+
+  IMPORTANT NOTE: Normally, ~denote~ does not save the buffer it
+  produces for the new note.  This is a safety precaution to not write
+  to disk unless the user wants it (e.g. the user may choose to kill the
+  buffer, thus cancelling the creation of the note).  However, for this
+  command the creation of the note happens in the background and the
+  user may miss the step of saving their buffer.  We thus have to save
+  the buffer in order to (i) establish valid links, and (ii) retrieve
+  whatever front matter from the target file.
+
+#+findex: denote-link-or-create
++ ~denote-link-or-create~ :: Use ~denote-link~ on =TARGET= file,
+  creating it if necessary.
+
+  If =TARGET= file does not exist, call ~denote-link-after-creating~
+  which runs the ~denote~ command interactively to create the file.  The
+  established link will then be targeting that new file.
+
+  If =TARGET= file does not exist, add the user input that was used to
+  search for it to the history of the ~denote-file-prompt~.  The user
+  can then retrieve and possibly further edit their last input, using
+  it as the newly created note's actual title.  At the ~denote-file-prompt~
+  type =M-p= with the default key bindings, which calls ~previous-history-element~.
+
+  With optional =ID-ONLY= as a prefix argument create a link with just
+  the file's identifier.  This has the same meaning as in ~denote-link~.
+
+  This command has the alias ~denote-link-to-existing-or-new-note~,
+  which helps with discoverability.
+
+** The backlinks' buffer
+:PROPERTIES:
+:CUSTOM_ID: h:c73f1f68-e214-49d5-b369-e694f6a5d708
+:END:
+
+#+findex: denote-backlinks
+The command ~denote-backlinks~ produces a bespoke buffer which
+displays backlinks to the current note.  A "backlink" is a link back
+to the present entry.
+
+By default, the backlinks' buffer is designed to display the file name
+of the note linking to the current entry.  Each file name is presented
+on its own line, like this:
+
+#+begin_example
+Backlinks to "On being honest" (20220614T130812)
+------------------------------------------------
+
+20220614T145606--let-this-glance-become-a-stare__journal.txt
+20220616T182958--feeling-butterflies-in-your-stomach__journal.txt
+#+end_example
+
+#+vindex: denote-backlinks-show-context
+When the user option ~denote-backlinks-show-context~ is non-nil, the
+backlinks' buffer displays the line on which a link to the current
+note occurs.  It also shows multiple occurrences, if present.  It looks
+like this (and has the appropriate fontification):
+
+#+begin_example
+Backlinks to "On being honest" (20220614T130812)
+------------------------------------------------
+
+20220614T145606--let-this-glance-become-a-stare__journal.txt
+37: growing into it: [[denote:20220614T130812][On being honest]].
+64: As I said in [[denote:20220614T130812][On being honest]] I have never
+20220616T182958--feeling-butterflies-in-your-stomach__journal.txt
+62: indifference.  In [[denote:20220614T130812][On being honest]] I alluded
+#+end_example
+
+Note that the width of the lines in the context depends on the
+underlying file.  In the above example, the lines are split at the
+~fill-column~.  Long lines will show up just fine.  Also note that the
+built-in user option ~xref-truncation-width~ can truncate long lines
+to a given maximum number of characters.
+
+[[#h:893eec49-d7be-4603-bcff-fcc247244011][Speed up backlinks' buffer creation?]]
+
+#+findex: denote-backlinks-mode
+#+vindex: denote-backlinks-mode-map
+The backlinks' buffer runs the major-mode ~denote-backlinks-mode~.  It
+binds keys to move between links with =n= (next) and =p= (previous).
+These are stored in the ~denote-backlinks-mode-map~ (use =M-x
+describe-mode= (=C-h m=) in an unfamiliar buffer to learn more about
+it).  When the user option ~denote-backlinks-show-context~ is non-nil,
+all relevant Xref key bindings are fully functional: again, check
+~describe-mode~.
+
+The backlinking facility uses Emacs' built-in Xref infrastructure.  On
+some operating systems, the user may need to add certain executables
+to the relevant environment variable.
+
+[[#h:42f6b07e-5956-469a-8294-17f9cf62eb2b][Why do I get "Search failed with status 1" when I search for backlinks?]]
+
+Backlinks to the current file can also be visited by using the
+minibuffer completion interface with the ~denote-find-backlink~
+command ([[#h:1bc2adad-dca3-4878-b9f0-b105d5dec6f4][Visiting linked files via the minibuffer]]).
+
+#+vindex: denote-link-backlinks-display-buffer-action
+The placement of the backlinks' buffer is subject to the user option
+~denote-link-backlinks-display-buffer-action~.  Due to the nature of the
+underlying ~display-buffer~ mechanism, this inevitably is a relatively
+advanced feature.  By default, the backlinks' buffer is displayed below
+the current window.  The doc string of our user option includes a sample
+configuration that places the buffer in a left side window instead.
+Reproducing it here for the sake of convenience:
+
+#+begin_src emacs-lisp
+(setq denote-link-backlinks-display-buffer-action
+      '((display-buffer-reuse-window
+         display-buffer-in-side-window)
+        (side . left)
+        (slot . 99)
+        (window-width . 0.3)))
+#+end_src
+
+** Writing metanotes
+:PROPERTIES:
+:CUSTOM_ID: h:6060a7e6-f179-4d42-a9de-a9968aaebecc
+:END:
+
+A "metanote" is an entry that describes other entries who have something
+in common.  Writing metanotes can be part of a workflow where the user
+periodically reviews their work in search of patterns and deeper
+insights.  For example, you might want to read your journal entries from
+the past year to reflect on your experiences, evolution as a person, and
+the like.
+
+The commands ~denote-add-links~, ~denote-link-dired-marked-notes~ are
+suited for this task.
+
+[[#h:9bec2c83-36ca-4951-aefc-7187c5463f90][Insert links matching a regexp]].
+
+[[#h:9cbb692e-5d8a-44a6-9193-899a07872a07][Insert links from marked files in Dired]].
+
+You will create your metanote the way you use Denote ordinarily
+(metanotes may have the =metanote= keyword, among others), write an
+introduction or however you want to go about it, invoke the command
+which inserts multiple links at once (see the above-cited nodes), and
+continue writing.
+
+Metanotes can serve as entry points to groupings of individual notes.
+They are not the same as a filtered list of files, i.e. what you would
+do in Dired or the minibuffer where you narrow the list of notes to a
+given query.  Metanotes contain the filtered list plus your thoughts
+about it.  The act of purposefully grouping notes together and
+contemplating on their shared patterns is what adds value.
+
+Your future self will appreciate metanotes for the function they serve
+in encapsulating knowledge, while current you will be equipped with the
+knowledge derived from the deliberate self-reflection.
+
+** Visiting linked files via the minibuffer
+:PROPERTIES:
+:CUSTOM_ID: h:1bc2adad-dca3-4878-b9f0-b105d5dec6f4
+:END:
+
+#+findex: denote-find-link
+Denote has a major-mode-agnostic mechanism to collect all linked file
+references in the current buffer and return them as an appropriately
+formatted list.  This list can then be used in interactive commands.
+The ~denote-find-link~ is such a command.  It uses minibuffer
+completion to visit a file that is linked to from the current note.
+The candidates have the correct metadata, which is ideal for
+integration with other standards-compliant tools ([[#h:8ed2bb6f-b5be-4711-82e9-8bee5bb06ece][Extending Denote]]).
+For instance, a package such as =marginalia= will display accurate
+annotations, while the =embark= package will be able to work its magic
+such as in exporting the list into a filtered Dired buffer (i.e. a
+familiar Dired listing with only the files of the current minibuffer
+session).
+
+#+findex: denote-find-backlink
+To visit backlinks to the current note via the minibuffer, use
+~denote-find-backlink~.  This is an alternative to placing backlinks
+in a dedicated buffer ([[#h:c73f1f68-e214-49d5-b369-e694f6a5d708][The backlinks' buffer]]).
+
+** Miscellaneous information about links
+:PROPERTIES:
+:CUSTOM_ID: h:dd8f2231-8d77-49b9-acc4-af525c68b271
+:END:
+
+#+findex: denote-insert-link
+#+findex: denote-show-backlinks-buffer
+#+findex: denote-link-insert-links-matching-regexp
+For convenience, the ~denote-link~ command has an alias called
+~denote-insert-link~.  The ~denote-backlinks~ can also be used as
+~denote-show-backlinks-buffer~.  While ~denote-add-links~ is
+aliased ~denote-link-insert-links-matching-regexp~.  The purpose of
+these aliases is to offer alternative, more descriptive names of
+select commands.
+
+* Fontification in Dired
+:PROPERTIES:
+:CUSTOM_ID: h:337f9cf0-9f66-45af-b73f-f6370472fb51
+:END:
+
+#+findex: denote-dired-mode
+One of the upsides of Denote's file-naming scheme is the predictable
+pattern it establishes, which appears as a near-tabular presentation in
+a listing of notes (i.e. in Dired).  The ~denote-dired-mode~ can help
+enhance this impression, by fontifying the components of the file name
+to make the date (identifier) and keywords stand out.
+
+There are two ways to set the mode.  Either use it for all directories,
+which probably is not needed:
+
+#+begin_src emacs-lisp
+(add-hook 'dired-mode-hook #'denote-dired-mode)
+#+end_src
+
+#+vindex: denote-dired-directories
+#+findex: denote-dired-mode-in-directories
+Or configure the user option ~denote-dired-directories~ and then set up
+the function ~denote-dired-mode-in-directories~:
+
+#+begin_src emacs-lisp
+;; We use different ways to specify a path for demo purposes.
+(setq denote-dired-directories
+      (list denote-directory
+            (thread-last denote-directory (expand-file-name "attachments"))
+            (expand-file-name "~/Documents/vlog")))
+
+(add-hook 'dired-mode-hook #'denote-dired-mode-in-directories)
+#+end_src
+
+The faces we define for this purpose are:
+
+#+vindex: denote-faces-date
+#+vindex: denote-faces-delimiter
+#+vindex: denote-faces-extension
+#+vindex: denote-faces-keywords
+#+vindex: denote-faces-subdirectory
+#+vindex: denote-faces-time
+#+vindex: denote-faces-title
++ ~denote-faces-date~
++ ~denote-faces-delimiter~
++ ~denote-faces-extension~
++ ~denote-faces-keywords~
++ ~denote-faces-subdirectory~
++ ~denote-faces-time~
++ ~denote-faces-title~
+
+For the time being, the =diredfl= package is not compatible with this
+facility.
+
+The ~denote-dired-mode~ does not only fontify note files that were
+created by Denote: it covers every file name that follows our naming
+conventions ([[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]]).  This is particularly useful for
+scenaria where, say, one wants to organise their collection of PDFs and
+multimedia in a systematic way (and, perhaps, use them as attachments
+for the notes Denote produces if you are writing Org notes and are using
+its standand attachments' facility).
+
+* Automatically rename Denote buffers
+:PROPERTIES:
+:CUSTOM_ID: h:3ca4db16-8f26-4d7d-b748-bac48ae32d69
+:END:
+
+#+findex: denote-rename-buffer-mode
+The ~denote-rename-buffer-mode~ minor mode provides the means to
+automatically rename the buffer of a Denote file upon visiting the
+file.  A buffer is renamed upon visiting the underlying file.  This
+means that existing buffers are not renamed until they are visited
+again in a new buffer (files are visited with the command ~find-file~
+or related).  Enable the mode thus:
+
+#+begin_src emacs-lisp
+(denote-rename-buffer-mode 1)
+#+end_src
+
+The default behaviour is to rename the buffer based on the file's
+title, which is retrieved from the front matter or from the =TITLE=
+component of the file name ([[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]]).
+
+#+vindex: denote-rename-buffer-function
+Customize the user option ~denote-rename-buffer-function~ to affect
+how buffers are renamed.  Its value must be the symbol of a function.
+The default is the ~denote-rename-buffer-with-title~, with an
+alternative of ~denote-rename-buffer-with-identifier~.
+
+The user option also accepts an arbitrary function.  Refer to the
+implementation details of ~denote-rename-buffer-with-title~ or
+~denote-rename-buffer-with-identifier~ for guidance on how to write a
+custom function.
+
+Note that renaming a buffer is not the same as renaming a file
+([[#h:532e8e2a-9b7d-41c0-8f4b-3c5cbb7d4dca][Renaming files]]).  The former is just for convenience inside of Emacs.
+Whereas the latter is for writing changes to disk, making them
+available to all programs.
+
+* Use Org dynamic blocks
+:PROPERTIES:
+:CUSTOM_ID: h:8b542c50-dcc9-4bca-8037-a36599b22779
+:END:
+
+Denote can optionally integrate with Org mode's "dynamic blocks"
+facility.  Start by loading the relevant library:
+
+#+begin_src emacs-lisp
+;; Register Denote's Org dynamic blocks
+(require 'denote-org-dblock)
+#+end_src
+
+A dynamic block gets its contents by evaluating a given function,
+depending on the type of block.  The type of block and its parameters
+are stated in the opening =#+BEGIN= line of the block.  Typing =C-c C-c=
+with point on that line runs the function, with the given arguments,
+and populates the block's contents accordingly.
+
+Denote leverages Org dynamic blocks to streamline the inclusion of (i)
+links to notes whose name matches a given search query (like
+~denote-add-links~) and (ii) backlinks to the current note (similar to
+~denote-find-backlink~).
+
+These two types of blocks are named =denote-links= and =denote-backlinks=
+respectively.  The latter does not accept any parameters, while the
+former does, which we explain below by also demonstrating how dynamic
+blocks are written.
+
+A dynamic block looks like this:
+
+: #+BEGIN: denote-links :regexp "_journal"
+:
+: #+END:
+
+Here we have the =denote-links= type, with the =:regexp= parameter.
+The value of the =:regexp= parameter is the same as that of the
+command ~denote-add-links~ ([[#h:9bec2c83-36ca-4951-aefc-7187c5463f90][Insert links matching a regexp]]).  It can
+only use the notation of the ~rx~ macro, as explained in the Emacs
+Lisp Reference Manual (evaluate: =(info "(elisp) Rx Notation")=).  The
+linked entry provides practical examples of patterns that make good
+use of Denote's file-naming scheme ([[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]]).
+
+In this example, we instruct Org to produce a list of all notes that
+include the =journal= keyword in their file name (keywords in file
+names are prefixed with the underscore).  So the following:
+
+: #+BEGIN: denote-links :regexp "_journal"
+:
+: #+END:
+
+Becomes something like this once we type =C-c C-c= with point on the
+=#+BEGIN= line (Org makes the links look prettier by default):
+
+: #+BEGIN: denote-links :regexp "_journal"
+: - [[denote:20220616T182958][Feeling butterflies in your stomach]]
+: - [[denote:20220818T221036][Between friend and stranger]]
+: #+END:
+
+The dynamic block takes care to keep the list in order and to add any
+missing links when the block is evaluated anew.
+
+Depending on one's workflow, the dynamic block can be instructed to
+list only those links which are missing from the current buffer
+(similar to ~denote-add-missing-links~).  Adding the =:missing-only=
+parameter with a non-~nil~ value achieves this effect. The =#+BEGIN=
+line looks like this:
+
+: #+BEGIN: denote-links :regexp "_journal" :missing-only t
+
+To reverse the order links appear in, add =:reverse t= to the
+=#+BEGIN= line.
+
+The =denote-links= block can also accept a =:block-name= parameter
+with a string value that names the block.  Once the dynamic block is
+evaluated, a =#+NAME= is prepended to the block's contents.  This can
+be referenced in other source blocks to parse the named block's
+contents as input of another process.  The details are beyond the
+scope of Denote.
+
+As for the =denote-backlinks= dynamic block type, it simply produces a
+list of notes that link to the current file.  It accepts no parameters
+and looks like this:
+
+: #+BEGIN: denote-backlinks
+:
+: #+END:
+
+The Org manual describes the technicalities of Dynamic Blocks.
+Evaluate:
+
+#+begin_src emacs-lisp
+(info "(org) Dynamic Blocks")
+#+end_src
+
+Dynamic blocks are particularly useful for metanote entries that
+reflect on the status of earlier notes ([[#h:6060a7e6-f179-4d42-a9de-a9968aaebecc][Writing metanotes]]).
+
+* Minibuffer histories
+:PROPERTIES:
+:CUSTOM_ID: h:82dc1203-d689-44b2-9a6c-b37776209651
+:END:
+
+Denote has a dedicated minibuffer history for each one of its prompts.
+This practically means that using =M-p= (~previous-history-element~) and
+=M-n= (~next-history-element~) will only cycle through the relevant
+record of inputs, such as your latest titles in the =TITLE= prompt, and
+keywords in the =KEYWORDS= prompt.
+
+The built-in =savehist= library saves minibuffer histories.  Sample
+configuration:
+
+#+begin_src emacs-lisp
+(require 'savehist)
+(setq savehist-file (locate-user-emacs-file "savehist"))
+(setq history-length 500)
+(setq history-delete-duplicates t)
+(setq savehist-save-minibuffer-history t)
+(add-hook 'after-init-hook #'savehist-mode)
+#+end_src
+
+* Extending Denote
+:PROPERTIES:
+:CUSTOM_ID: h:8ed2bb6f-b5be-4711-82e9-8bee5bb06ece
+:END:
+
+Denote is a tool with a narrow scope: create notes and link between
+them, based on the aforementioned file-naming scheme.  For other common
+operations the user is advised to rely on standard Emacs facilities or
+specialised third-party packages.  This section covers the details.
+
+** Keep a journal or diary
+:PROPERTIES:
+:CUSTOM_ID: h:4a6d92dd-19eb-4fcc-a7b5-05ce04da3a92
+:END:
+
+While there are subtle technical differences between a journal and a
+diary, we will consider those equivalent in the interest of brevity:
+they both describe a personal space that holds a record of your thoughts
+about your experiences and/or view of events in the world.
+
+Suppose you are committed to writing an entry every day.  Unlike what we
+demonstrated before, your writing will follow a regular naming pattern.
+You know that the title of the new note must always look like =Tuesday
+14 June 2022= and the keyword has to be =journal= or =diary=.  As such,
+you want to automate the task instead of being prompted each time, as is
+the norm with ~denote~ and the relevant commands ([[#h:17896c8c-d97a-4faa-abf6-31df99746ca6][Points of entry]]).
+This is easy to accomplish because ~denote~ can be called from Lisp and
+given the required arguments of =TITLE= and =KEYWORDS= directly.  All
+you need is a simple wrapper function:
+
+#+begin_src emacs-lisp
+(defun my-denote-journal ()
+  "Create an entry tagged 'journal' with the date as its title."
+  (interactive)
+  (denote
+   (format-time-string "%A %e %B %Y") ; format like Tuesday 14 June 2022
+   '("journal"))) ; multiple keywords are a list of strings: '("one" "two")
+#+end_src
+
+By invoking ~my-denote-journal~ you will go straight into the newly
+created note and commit to your writing outright.
+
+Of course, you can always set up the function so that it asks for a
+=TITLE= but still automatically applies the =journal= tag:
+
+#+begin_src emacs-lisp
+(defun denote-journal-with-title ()
+  "Create an entry tagged 'journal', while prompting for a title."
+  (interactive)
+  (denote
+   (denote-title-prompt) ; ask for title, instead of using human-readable date
+   '("journal")))
+#+end_src
+
+The above snippets do not check if a daily entry exists: they always
+create a new one.  The idea is that one may want to write multiple
+journal entries per day.  Another approach is to create a single entry
+on a given day, in which case the command must be repurposed to
+surface the existing note, if present.  As with ~my-denote-journal~
+above, the title is formatted as =Tuesday 14 June 2022=.
+
+#+begin_src emacs-lisp
+(defun my-denote-journal ()
+  "Create an entry tagged 'journal' with the date as its title.
+If a journal for the current day exists, visit it.  If multiple
+entries exist, prompt with completion for a choice between them.
+Else create a new file."
+  (interactive)
+  (let* ((today (format-time-string "%A %e %B %Y"))
+         (string (denote-sluggify today))
+         (files (denote-directory-files-matching-regexp string)))
+    (cond
+     ((> (length files) 1)
+      (find-file (completing-read "Select file: " files nil :require-match)))
+     (files
+      (find-file (car files)))
+     (t
+      (denote
+       today
+       '("journal"))))))
+#+end_src
+
+*** Journaling with a timer
+:PROPERTIES:
+:CUSTOM_ID: h:4af1f81e-e93a-43cc-b344-960032a16d42
+:END:
+
+Sometimes journaling is done with the intent to hone one's writing
+skills.  Perhaps you are learning a new language or wish to communicate
+your ideas with greater clarity and precision.  As with everything that
+requires a degree of sophistication, you have to work for it---write,
+write, write!
+
+One way to test your progress is to set a timer.  It helps you gauge
+your output and its quality.  To use a timer with Emacs, consider the
+=tmr= package:
+
+#+begin_src emacs-lisp
+(defun my-denote-journal-with-tmr ()
+  "Like `my-denote-journal', but also set a 10-minute timer.
+The `tmr' command is part of the `tmr' package."
+  (interactive)
+  (denote
+   (format-time-string "%A %e %B %Y")
+   '("journal"))
+  (tmr "10" "Practice writing in my journal")) ; set 10 minute timer with a description
+#+end_src
+
+Once the timer elapses, stop writing and review your performance.
+Practice makes perfect!
+
+[ As Denote matures, we may add hooks to control what happens before or
+  after the creation of a new note.  We shall also document more
+  examples of tasks that can be accomplished with this package. ]
+
+Sources for =tmr=:
+
++ Package name (GNU ELPA): =tmr=
++ Official manual: <https://protesilaos.com/emacs/tmr>
++ Change log: <https://protesilaos.com/emacs/denote-changelog>
++ Git repo on SourceHut: <https://git.sr.ht/~protesilaos/tmr>
+  - Mirrors:
+    + GitHub: <https://github.com/protesilaos/tmr>
+    + GitLab: <https://gitlab.com/protesilaos/tmr>
++ Mailing list: <https://lists.sr.ht/~protesilaos/tmr>
+
+** Create a note with the region's contents
+:PROPERTIES:
+:CUSTOM_ID: h:2f8090f1-50af-4965-9771-d5a91a0a87bd
+:END:
+
+Sometimes it makes sense to gather notes in a single file and later
+review it to make multiple notes out of it.  With the following code,
+the user marks a region and then invokes the command
+~my-denote-create-new-note-from-region~: it prompts for a title and
+keywords and then uses the region's contents to fill in the newly
+created note.
+
+#+begin_src emacs-lisp
+(defun my-denote-create-new-note-from-region (beg end)
+  "Create note whose contents include the text between BEG and END.
+Prompt for title and keywords of the new note."
+  (interactive "r")
+  (if-let (((region-active-p))
+           (text (buffer-substring-no-properties beg end)))
+      (progn
+        (denote (denote-title-prompt) (denote-keywords-prompt))
+        (insert text))
+    (user-error "No region is available")))
+#+end_src
+
+Have a different workflow?  Feel welcome to discuss it in any of our
+official channels ([[#h:1ebe4865-c001-4747-a6f2-0fe45aad71cd][Contributing]]).
+
+** Split an Org subtree into its own note
+:PROPERTIES:
+:CUSTOM_ID: h:d0c7cb79-21e5-4176-a6af-f4f68578c8dd
+:END:
+
+With Org files in particular, it is common to have nested headings
+which could be split off into their own standalone notes.  In Org
+parlance, an entry with all its subheadings is a "subtree".  With the
+following code, the user places the point inside the heading they want
+to split off and invokes the command ~my-denote-org-extract-subtree~.
+It will create a note using the heading's text and tags for the new
+file.  The contents of the subtree become the contents of the new note
+and are removed from the old one.
+
+#+begin_src emacs-lisp
+(defun my-denote-org-extract-subtree (&optional silo)
+  "Create new Denote note using current Org subtree.
+Make the new note use the Org file type, regardless of the value
+of `denote-file-type'.
+
+With an optional SILO argument as a prefix (\\[universal-argument]),
+ask user to select a SILO from `my-denote-silo-directories'.
+
+Use the subtree title as the note's title.  If available, use the
+tags of the heading are used as note keywords.
+
+Delete the original subtree."
+  (interactive
+   (list (when current-prefix-arg
+           (completing-read "Select a silo: " my-denote-silo-directories nil t))))
+  (if-let ((text (org-get-entry))
+           (heading (org-get-heading :no-tags :no-todo :no-priority :no-comment)))
+      (let ((element (org-element-at-point))
+            (tags (org-get-tags))
+            (denote-user-enforced-denote-directory silo))
+        (delete-region (org-entry-beginning-position)
+                       (save-excursion (org-end-of-subtree t) (point)))
+        (denote heading
+                tags
+                'org
+                nil
+                (or
+                 ;; Check PROPERTIES drawer for :created: or :date:
+                 (org-element-property :CREATED element)
+                 (org-element-property :DATE element)
+                 ;; Check the subtree for CLOSED
+                 (org-element-property :raw-value
+                                       (org-element-property :closed element))))
+        (insert text))
+    (user-error "No subtree to extract; aborting")))
+#+end_src
+
+Have a different workflow?  Feel welcome to discuss it in any of our
+official channels ([[#h:1ebe4865-c001-4747-a6f2-0fe45aad71cd][Contributing]]).
+
+** Narrow the list of files in Dired
+:PROPERTIES:
+:CUSTOM_ID: h:ea173a01-69ef-4574-89a7-6e60ede02f13
+:END:
+
+Emacs' standard file manager (or directory editor) can read a regular
+expression to mark the matching files.  This is the command
+~dired-mark-files-regexp~, which is bound to =% m= by default.  For
+example, =% m _denote= will match all files that have the =denote=
+keyword ([[#h:1a953736-86c2-420b-b566-fb22c97df197][Features of the file-naming scheme for searching or filtering]]).
+
+Once the files are matched, the user has to options: (i) narrow the list
+to the matching items or (ii) exclude the matching items from the list.
+
+For the former, we want to toggle the marks by typing =t= (calls the
+command ~dired-toggle-marks~ by default) and then hit the letter =k=
+(for ~dired-do-kill-lines~).  The remaining files are those that match
+the regexp that was provided earlier.
+
+For the latter approach of filtering out the matching items, simply
+involves the use of the =k= command (~dired-do-kill-lines~) to omit the
+marked files from the list.
+
+These sequences can be combined to incrementally narrow the list.  Note
+that ~dired-do-kill-lines~ does not delete files: it simply hides them
+from the current view.
+
+Revert to the original listing with =g= (~revert-buffer~).
+
+For a convenient wrapper, consider this example:
+
+#+begin_src emacs-lisp
+(defvar prot-dired--limit-hist '()
+  "Minibuffer history for `prot-dired-limit-regexp'.")
+
+;;;###autoload
+(defun prot-dired-limit-regexp (regexp omit)
+  "Limit Dired to keep files matching REGEXP.
+
+With optional OMIT argument as a prefix (\\[universal-argument]),
+exclude files matching REGEXP.
+
+Restore the buffer with \\<dired-mode-map>`\\[revert-buffer]'."
+  (interactive
+   (list
+    (read-regexp
+     (concat "Files "
+             (when current-prefix-arg
+               (propertize "NOT " 'face 'warning))
+             "matching PATTERN: ")
+     nil 'prot-dired--limit-hist)
+    current-prefix-arg))
+  (dired-mark-files-regexp regexp)
+  (unless omit (dired-toggle-marks))
+  (dired-do-kill-lines))
+#+end_src
+
+** Use ~dired-virtual-mode~ for arbitrary file listings
+:PROPERTIES:
+:CUSTOM_ID: h:d35d8d41-f51b-4139-af8f-9c8cc508e35b
+:END:
+
+Emacs' Dired is a powerful file manager that builds its functionality
+on top of the Unix =ls= command.  As noted elsewhere in this manual,
+the user can update the =ls= flags that Dired uses to display its
+contents ([[#h:a7fd5e0a-78f7-434e-aa2e-e150479c16e2][I want to sort by last modified, why won't Denote let me?]]).
+
+What Dired cannot do is parse the output of a result that is produced
+by piped commands, such as =ls -l | sort -t _ -k2=.  This specific
+example targets the second underscore-separated field of the file
+name, per our conventions ([[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]]).  Conceretely, it
+matches the "alpha" as the sorting key in something like this:
+
+#+begin_src emacs-lisp
+20220929T200432--testing-file-one__alpha.txt
+#+end_src
+
+Consider then, how Dired will sort those files by their identifier:
+
+#+begin_src emacs-lisp
+20220929T200432--testing-file-one__alpha.txt
+20220929T200532--testing-file-two__beta.txt
+20220929T200632--testing-file-three__alpha.txt
+20220929T200732--testing-file-four__beta.txt
+#+end_src
+
+Whereas on the command line, we can get the following:
+
+#+begin_example
+$ ls | sort -t _ -k 2
+20220929T200432--testing-file-one__alpha.txt
+20220929T200632--testing-file-three__alpha.txt
+20220929T200532--testing-file-two__beta.txt
+20220929T200732--testing-file-four__beta.txt
+#+end_example
+
+This is where ~dired-virtual-mode~ shows its utility.  If we tweak our
+command-line invocation to include =ls -l=, this mode can behave like
+Dired on the listed files.  (We omit the output of the =-l= flag from
+this tutorial, as it is too verbose.)
+
+What we now need is to capture the output of =ls -l | sort -t _ -k 2=
+in an Emacs buffer and then enable ~dired-virtual-mode~.  To do that,
+we can rely on either =M-x shell= or =M-x eshell= and then manually
+copy the relevant contents.
+
+For the user's convenience, I share what I have for Eshell to quickly
+capture the last command's output in a dedicated buffer:
+
+#+begin_src emacs-lisp
+(defcustom prot-eshell-output-buffer "*Exported Eshell output*"
+  "Name of buffer with the last output of Eshell command.
+Used by `prot-eshell-export'."
+  :type 'string
+  :group 'prot-eshell)
+
+(defcustom prot-eshell-output-delimiter "* * *"
+  "Delimiter for successive `prot-eshell-export' outputs.
+This is formatted internally to have newline characters before
+and after it."
+  :type 'string
+  :group 'prot-eshell)
+
+(defun prot-eshell--command-prompt-output ()
+  "Capture last command prompt and its output."
+  (let ((beg (save-excursion
+               (goto-char (eshell-beginning-of-input))
+               (goto-char (point-at-bol)))))
+    (when (derived-mode-p 'eshell-mode)
+      (buffer-substring-no-properties beg (eshell-end-of-output)))))
+
+;;;###autoload
+(defun prot-eshell-export ()
+  "Produce a buffer with output of the last Eshell command.
+If `prot-eshell-output-buffer' does not exist, create it.  Else
+append to it, while separating multiple outputs with
+`prot-eshell-output-delimiter'."
+  (interactive)
+  (let ((eshell-output (prot-eshell--command-prompt-output)))
+    (with-current-buffer (get-buffer-create prot-eshell-output-buffer)
+      (let ((inhibit-read-only t))
+        (goto-char (point-max))
+        (unless (eq (point-min) (point-max))
+          (insert (format "\n%s\n\n" prot-eshell-output-delimiter)))
+        (goto-char (point-at-bol))
+        (insert eshell-output)
+        (switch-to-buffer-other-window (current-buffer))))))
+#+end_src
+
+Bind ~prot-eshell-export~ to a key in the ~eshell-mode-map~ and give
+it a try (I use =C-c C-e=).  In the produced buffer, activate the
+~dired-virtual-mode~.
+
+** Use Embark to collect minibuffer candidates
+:PROPERTIES:
+:CUSTOM_ID: h:edf9b651-86eb-4d5f-bade-3c9e270082f0
+:END:
+
+=embark= is a remarkable package that lets you perform relevant,
+context-dependent actions using a prefix key (simplifying in the
+interest of brevity).
+
+For our purposes, Embark can be used to produce a Dired listing
+directly from the minibuffer.  Suppose the current note has links to
+three other notes.  You might use the ~denote-find-link~ command to
+pick one via the minibuffer.  But why not turn those three links into
+their own Dired listing?  While in the minibuffer, invoke ~embark-act~
+which you may have already bound to =C-.= and then follow it up with
+=E= (for the ~embark-export~ command).
+
+This pattern can be repeated with any list of candidates, meaning that
+you can narrow the list by providing some input before eventually
+exporting the results with Embark.
+
+Overall, this is very powerful and you might prefer it over doing the
+same thing directly in Dired, since you also benefit from all the power
+of the minibuffer ([[#h:ea173a01-69ef-4574-89a7-6e60ede02f13][Narrow the list of files in Dired]]).
+
+** Search file contents
+:PROPERTIES:
+:CUSTOM_ID: h:76198fab-d6d2-4c67-9ccb-7a08cc883952
+:END:
+
+Emacs provides built-in commands which are wrappers of standard Unix
+tools: =M-x grep= lets the user input the flags of a ~grep~ call and
+pass a regular expression to the =-e= flag.
+
+The author of Denote uses this thin wrapper instead:
+
+#+begin_src emacs-lisp
+(defvar prot-search--grep-hist '()
+  "Input history of grep searches.")
+
+;;;###autoload
+(defun prot-search-grep (regexp &optional recursive)
+  "Run grep for REGEXP.
+
+Search in the current directory using `lgrep'.  With optional
+prefix argument (\\[universal-argument]) for RECURSIVE, run a
+search starting from the current directory with `rgrep'."
+  (interactive
+   (list
+    (read-from-minibuffer (concat (if current-prefix-arg
+                                      (propertize "Recursive" 'face 'warning)
+                                    "Local")
+                                  " grep for PATTERN: ")
+                          nil nil nil 'prot-search--grep-hist)
+    current-prefix-arg))
+  (unless grep-command
+    (grep-compute-defaults))
+  (if recursive
+      (rgrep regexp "*" default-directory)
+    (lgrep regexp "*" default-directory)))
+#+end_src
+
+Rather than maintain custom code, consider using the excellent =consult=
+package: it provides commands such as ~consult-grep~ and ~consult-find~
+which provide live results and are generally easier to use than the
+built-in commands.
+
+** Bookmark the directory with the notes
+:PROPERTIES:
+:CUSTOM_ID: h:1bba4c1e-6812-4749-948f-57df4fd49b36
+:END:
+
+Part of the reason Denote does not reinvent existing functionality is to
+encourage you to learn more about Emacs.  You do not need a bespoke
+"jump to my notes" directory because such commands do not scale well.
+Will you have a "jump to my downloads" then another for multimedia and
+so on?  No.
+
+Emacs has a built-in framework for recording persistent markers to
+locations.  Visit the ~denote-directory~ (or any dir/file for that
+matter) and invoke the ~bookmark-set~ command (bound to =C-x r m= by
+default).  It lets you create a bookmark.
+
+The list of bookmarks can be reviewed with the ~bookmark-bmenu-list~
+command (bound to =C-x r l= by default).  A minibuffer interface is
+available with ~bookmark-jump~ (=C-x r b=).
+
+If you use the =consult= package, its default ~consult-buffer~ command
+has the means to group together buffers, recent files, and bookmarks.
+Each of those types can be narrowed to with a prefix key.  The package
+=consult-dir= is an extension to =consult= which provides useful extras
+for working with directories, including bookmarks.
+
+** Use the ~citar-denote~ package for bibliography notes
+:PROPERTIES:
+:CUSTOM_ID: h:226d66e4-b7de-4617-87e2-a7f2d6f007dd
+:END:
+
+Peter Prevos has produced the ~citar-denote~ package which makes it
+possible to write notes on BibTeX entries with the help of the ~citar~
+package.  These notes have the citation's unique key associated with
+them in the file's front matter.  They also get a configurable keyword
+in their file name, making it easy to find them in Dired and/or
+retrieve them with the various Denote methods.
+
+With ~citar-denote~, the user leverages standard minibuffer completion
+mechanisms (e.g. with the help of the ~vertico~ and ~embark~ packages)
+to manage bibliographic notes and access those notes with ease.  The
+package's documentation covers the details: <https://github.com/pprevos/citar-denote/>.
+
+** Use the ~consult-notes~ package
+:PROPERTIES:
+:CUSTOM_ID: h:8907f4bc-992a-45bc-a60e-267ed1ce9c2d
+:END:
+
+If you are using Daniel Mendler's ~consult~ (which is a brilliant
+package), you will most probably like its ~consult-notes~ extension,
+developed by Colin McLear.  It uses the familiar mechanisms of Consult
+to preview the currently selected entry and to filter searches via a
+prefix key.  For example:
+
+#+begin_src emacs-lisp
+(setq consult-notes-file-dir-sources
+      `(("Denote Notes"  ?d ,(denote-directory))
+        ("Books"  ?b "~/Documents/books/")))
+#+end_src
+
+With the above, =M-x consult-notes= will list the files in those two
+directories.  If you type =d= and space, it narrows the list to just
+the notes, while =b= does the same for books.
+
+The other approach is to enable the ~consult-notes-denote-mode~.  It
+takes care to add the ~denote-directory~ to the sources that
+~consult-notes~ reads from.  Denote notes are then filtered by the =d=
+prefix followed by a space.
+
+The minor mode has the extra feature of reformatting the title of
+notes shown in the minibuffer.  It isolates the =TITLE= component of
+each note and shows it without hyphens, while presenting keywords in
+their own column.  The user option ~consult-notes-denote-display-id~
+can be set to ~nil~ to hide the identifier.  Depending on how one
+searches through their notes, this refashioned presentation may be the
+best option ([[#h:1a953736-86c2-420b-b566-fb22c97df197][Features of the file-naming scheme for searching or filtering]]).
+
+** Use the ~denote-menu~ package
+:PROPERTIES:
+:CUSTOM_ID: h:472db709-27de-4a1f-a171-c3fe0a7a9be8
+:END:
+
+Denote's file-naming scheme is designed to be efficient and to provide
+valueable meta information about the file.  The cost, however, is that
+it is terse and harder to read, depending on how the user chooses to
+filter and process their notes.
+
+To this end, [[https://github.com/namilus/denote-menu][the ~denote-menu~ package by Mohamed Suliman]] provides the
+convenience of a nice tabular interface for all notes.  ~denote-menu~
+removes the delimiters that are found in Denote file names and
+presents the information in a human-readable format.  Furthermore, the
+package provides commands to interact with the list of notes, such as
+to filter them and to transition from the tabular list to Dired.  Its
+documentation expands on the technicalities.
+
+** Treat your notes as a project
+:PROPERTIES:
+:CUSTOM_ID: h:fad3eb08-ddc7-43e4-ba28-210d89668037
+:END:
+
+Emacs has a built-in library for treating a directory tree as a
+"project".  This means that the contents of this tree are seen as part
+of the same set, so commands like ~project-switch-to-buffer~ (=C-x p b=
+by default) will only consider buffers in the current project
+(e.g. three notes that are currently being visited).
+
+Normally, a "project" is a directory tree whose root is under version
+control.  For our purposes, all you need is to navigate to the
+~denote-directory~ (for the shell or via Dired) and use the command-line
+to run this (requires the =git= executable):
+
+: git init
+
+From Dired, you can type =M-!= which invokes ~dired-smart-shell-command~
+and then run the git call there.
+
+The project can then be registered by invoking any project-related
+command inside of it, such as ~project-find-file~ (=C-x p f=).
+
+It is a good idea to keep your notes under version control, as that
+gives you a history of changes for each file.  We shall not delve into
+the technicalities here, though suffice to note that Emacs' built-in
+version control framework or the exceptionally well-crafted =magit=
+package will get the job done (VC can work with other backends besides
+Git).
+
+** Make variants of ~denote-open-or-create~
+:PROPERTIES:
+:CUSTOM_ID: h:ad91ca39-cf10-4e16-b224-fdf78f093883
+:END:
+
+#+findex: denote-open-or-create
+The command ~denote-open-or-create~ prompts to visit a file in the
+~denote-directory~.  If the user input does not have any matches,
+~denote-open-or-create~ will call the ~denote~ command interactively.
+It will then use whatever prompts ~denote~ normally has, per the user
+option ~denote-prompts~ ([[#h:6a92a8b5-d766-42cc-8e5b-8dc255466a23][Standard note creation]]).
+
+To speed up the process or to maintain variants that suit one's
+workflow, we provide these ready-to-use commands that one can add to
+their Emacs init file.  They can be assigned to key bindings or be used
+via =M-x= after they have been evaluated.
+
+#+begin_src emacs-lisp
+;;;###autoload
+(defun denote-open-or-create-with-date ()
+  "Invoke `denote-open-or-create' but also prompt for date.
+
+The date can be in YEAR-MONTH-DAY notation like 2022-06-30 or
+that plus the time: 2022-06-16 14:30.  When the user option
+`denote-date-prompt-use-org-read-date' is non-nil, the date
+prompt uses the more powerful Org+calendar system.
+
+This is the equivalent to calling `denote-open-or-create' when
+`denote-prompts' is set to \\='(date title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(date title keywords)))
+    (call-interactively #'denote-open-or-create)))
+
+;;;###autoload
+(defun denote-open-or-create-with-type ()
+  "Invoke `denote-open-or-create' but also prompt for file type.
+This is the equivalent to calling `denote-open-or-create' when
+`denote-prompts' is set to \\='(type title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(type title keywords)))
+    (call-interactively #'denote-open-or-create)))
+
+;;;###autoload
+(defun denote-open-or-create-with-subdirectory ()
+  "Invoke `denote-open-or-create' but also prompt for subdirectory.
+This is the equivalent to calling `denote-open-or-create' when
+`denote-prompts' is set to \\='(subdirectory title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(subdirectory title keywords)))
+    (call-interactively #'denote-open-or-create)))
+
+;;;###autoload
+(defun denote-open-or-create-with-template ()
+  "Invoke `denote-open-or-create' but also prompt for template.
+This is the equivalent to calling `denote-open-or-create' when
+`denote-prompts' is set to \\='(template title keywords).
+
+For templates, refer to `denote-templates'."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(template title keywords)))
+    (call-interactively #'denote-open-or-create)))
+#+end_src
+
+** Make variants of ~denote-link-or-create~
+:PROPERTIES:
+:CUSTOM_ID: h:b6056e6b-93df-4e6b-a778-eebd105bac46
+:END:
+
+#+findex: denote-link-or-create
+The command ~denote-link-or-create~ uses ~denote-link~ on a =TARGET=
+file, creating it if necessary.  The =TARGET= matches the user input at
+a minibuffer prompt: it is a file in the ~denote-directory~.
+
+#+findex: denote-link-after-creating
+If =TARGET= file does not exist, The ~denote-link-or-create~ calls
+~denote-link-after-creating~ which runs the standard ~denote~ command
+interactively to create the file ([[#h:6a92a8b5-d766-42cc-8e5b-8dc255466a23][Standard note creation]]).  The
+established link will then be targeting that new file.
+
+When called with an optional prefix argument (=C-u= by default)
+~denote-link-or-create~ creates a link that consists of just the
+identifier.  Else it tries to also include the file's title.  This has
+the same meaning as in ~denote-link~ ([[#h:fc913d54-26c8-4c41-be86-999839e8ad31][Linking notes]]).
+
+To speed up the process or to maintain variants that suit one's
+workflow, we provide these ready-to-use commands that one can add to
+their Emacs init file.  They can be assigned to key bindings or be used
+via =M-x= after they have been evaluated.
+
+#+begin_src emacs-lisp
+;;;###autoload
+(defun denote-link-or-create-with-date ()
+  "Invoke `denote-link-or-create' but also prompt for date.
+
+The date can be in YEAR-MONTH-DAY notation like 2022-06-30 or
+that plus the time: 2022-06-16 14:30.  When the user option
+`denote-date-prompt-use-org-read-date' is non-nil, the date
+prompt uses the more powerful Org+calendar system.
+
+This is the equivalent to calling `denote-link-or-create' when
+`denote-prompts' is set to \\='(date title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(date title keywords)))
+    (call-interactively #'denote-link-or-create)))
+
+;;;###autoload
+(defun denote-link-or-create-with-type ()
+  "Invoke `denote-link-or-create' but also prompt for file type.
+This is the equivalent to calling `denote-link-or-create' when
+`denote-prompts' is set to \\='(type title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(type title keywords)))
+    (call-interactively #'denote-link-or-create)))
+
+;;;###autoload
+(defun denote-link-or-create-with-subdirectory ()
+  "Invoke `denote-link-or-create' but also prompt for subdirectory.
+This is the equivalent to calling `denote-link-or-create' when
+`denote-prompts' is set to \\='(subdirectory title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(subdirectory title keywords)))
+    (call-interactively #'denote-link-or-create)))
+
+;;;###autoload
+(defun denote-link-or-create-with-template ()
+  "Invoke `denote-link-or-create' but also prompt for template.
+This is the equivalent to calling `denote-link-or-create' when
+`denote-prompts' is set to \\='(template title keywords).
+
+For templates, refer to `denote-templates'."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(template title keywords)))
+    (call-interactively #'denote-link-or-create)))
+#+end_src
+
+** Use the tree-based file prompt for select commands
+:PROPERTIES:
+:CUSTOM_ID: h:8f9e0971-8b30-4e7b-af79-8fed257dbcfa
+:END:
+
+Older versions of Denote had a file prompt that resembled that of the
+standard ~find-file~ command (bound to =C-x C-f= by default).  This
+means that it used a tree-based method of navigating the filesystem by
+selecting the specific directory and then the given file.
+
+Currently, Denote flattens the file prompt so that every file in the
+~denote-directory~ and its subdirectories can be matched from anywhere
+using the power of Emacs' minibuffer completion (such as with the help
+of the ~orderless~ package in addition to built-in options).
+
+Users who need the old behaviour on a per-command basis can define
+their own wrapper functions as shown in the following code block.
+
+#+begin_src emacs-lisp
+;; This is the old `denote-file-prompt' that we renamed to
+;; `denote-file-prompt-original' for clarity.
+(defun denote-file-prompt-original (&optional initial-text)
+  "Prompt for file with identifier in variable `denote-directory'.
+With optional INITIAL-TEXT, use it to prepopulate the minibuffer."
+  (read-file-name "Select note: " (denote-directory) nil nil initial-text
+                  (lambda (f)
+                    (or (denote-file-has-identifier-p f)
+                        (file-directory-p f)))))
+
+;; Our wrapper command that changes the current `denote-file-prompt'
+;; to the functionality of `denote-file-prompt-original' only when
+;; this command is used.
+(defun my-denote-link ()
+  "Call `denote-link' but use Denote's original file prompt.
+See `denote-file-prompt-original'."
+  (interactive)
+  (cl-letf (((symbol-function 'denote-file-prompt) #'denote-file-prompt-original))
+    (call-interactively #'denote-link)))
+#+end_src
+
+** Rename files with Denote in the Image Dired thumbnails buffer
+:PROPERTIES:
+:CUSTOM_ID: h:e666ced6-da75-4bdb-9be3-82c2f4455ee9
+:END:
+
+[[#h:2d5ee9bf-e8f2-426c-8bf7-bf78bc88d1ee][Rename files with Denote using ~dired-preview~]]
+
+Just as with the ~denote-dired-rename-marked-files~, we can use Denote
+in the Image Dired buffer ([[#h:1b6b2c78-42f0-45b8-9ef0-6de21a8b2cde][Rename multiple files at once]]).  Here is
+the custom code:
+
+#+begin_src emacs-lisp
+(autoload 'image-dired--with-marked "image-dired")
+(autoload 'image-dired-original-file-name "image-dired-util")
+
+(defun my-denote-image-dired-rename-marked-files (keywords)
+  "Like `denote-dired-rename-marked-files' but for Image Dired.
+Prompt for KEYWORDS and rename all marked files in the Image
+Dired buffer to have a Denote-style file name with the given
+KEYWORDS.
+
+IMPORTANT NOTE: if there are marked files in the corresponding
+Dired buffers, those will be targeted as well.  This is not the
+fault of Denote: it is how Dired and Image Dired work in tandem.
+To only rename the marked thumbnails, start by unmarking
+everything in Dired.  Then mark the items in Image Dired and
+invoke this command."
+  (interactive (list (denote-keywords-prompt)) image-dired-thumbnail-mode)
+  (image-dired--with-marked
+   (when-let* ((file (image-dired-original-file-name))
+               (dir (file-name-directory file))
+               (id (denote-retrieve-or-create-file-identifier file))
+               (file-type (denote-filetype-heuristics file))
+               (title (denote--retrieve-title-or-filename file file-type))
+               (extension (file-name-extension file t))
+               (new-name (denote-format-file-name dir id keywords title extension))
+               (default-directory dir))
+     (denote-rename-file-and-buffer file new-name))))
+#+end_src
+
+While the ~my-denote-image-dired-rename-marked-files~ renames files in
+the helpful Denote-compliant way, users may still need to not prepend
+a unique identifier and not sluggify (hyphenate and downcase) the
+image's existing file name.  To this end, the following custom command
+can be used instead:
+
+#+begin_src emacs-lisp
+(defun my-image-dired-rename-marked-files (keywords)
+  "Like `denote-dired-rename-marked-files' but for Image Dired.
+Prompt for keywords and rename all marked files in the Image
+Dired buffer to have Denote-style keywords, but none of the other
+conventions of Denote's file-naming scheme."
+  (interactive (list (denote-keywords-prompt)) image-dired-thumbnail-mode)
+  (image-dired--with-marked
+   (when-let* ((file (image-dired-original-file-name))
+               (dir (file-name-directory file))
+               (file-type (denote-filetype-heuristics file))
+               (title (denote--retrieve-title-or-filename file file-type))
+               (extension (file-name-extension file t))
+               (kws (denote--keywords-combine keywords))
+               (new-name (concat dir title "__" kws extension))
+               (default-directory dir))
+     (denote-rename-file-and-buffer file new-name))))
+#+end_src
+
+** Rename files with Denote using ~dired-preview~
+:PROPERTIES:
+:CUSTOM_ID: h:2d5ee9bf-e8f2-426c-8bf7-bf78bc88d1ee
+:END:
+
+The ~dired-preview~ package (by me/Protesilaos) automatically displays
+a preview of the file at point in Dired.  This can be helpful in
+tandem with Denote when we want to rename multiple files by taking a
+quick look at their contents.
+
+The command ~denote-dired-rename-marked-files~ will generate
+Denote-style file names based on the keywords it prompts for.
+Identifiers are derived from each file's modification date
+([[#h:1b6b2c78-42f0-45b8-9ef0-6de21a8b2cde][Rename multiple files at once]]).  There is no need for any custom
+code in this scenario.
+
+As noted in the section about Image Dired, the user may sometimes not
+need a fully fledged Denote-style file name but only append Denote-like
+keywords to each file name (e.g. =Original Name__denote_test.jpg=
+instead of =20230710T195843--original-name__denote_test.jpg=).
+
+[[#h:e666ced6-da75-4bdb-9be3-82c2f4455ee9][Rename files with Denote in the Image Dired thumbnails buffer]]
+
+In such a workflow, it is unlikely to be dealing with ordinary text
+files where front matter can be helpful.  A custom command does not
+need to behave like what Denote provides out-of-the-box, but can
+instead append keywords to file names without conducting any further
+actions.  We thus have:
+
+#+begin_src emacs-lisp
+(defun my-denote-dired-rename-marked-files-keywords-only ()
+  "Like `denote-dired-rename-marked-files' but only for keywords in file names.
+
+Prompt for keywords and rename all marked files in the Dired
+buffer to only have Denote-style keywords, but none of the other
+conventions of Denote's file-naming scheme."
+  (interactive nil dired-mode)
+  (if-let ((marks (dired-get-marked-files)))
+      (let ((keywords (denote-keywords-prompt)))
+        (dolist (file marks)
+          (let* ((dir (file-name-directory file))
+                 (file-type (denote-filetype-heuristics file))
+                 (title (denote--retrieve-title-or-filename file file-type))
+                 (extension (file-name-extension file t))
+                 (kws (denote--keywords-combine keywords))
+                 (new-name (concat dir title "__" kws extension)))
+            (denote-rename-file-and-buffer file new-name)))
+        (revert-buffer))
+    (user-error "No marked files; aborting")))
+#+end_src
+
+** Avoid duplicate identifiers when exporting Denote notes
+:PROPERTIES:
+:CUSTOM_ID: h:4a8c4546-26b3-4195-8b2c-b08a519986a4
+:END:
+
+When exporting Denote notes to, for example, an HTML or PDF file,
+there is a high probability that the same file name is used with a new
+extension.  This is problematic because it creates files with
+duplicate identifiers.  The =20230515T085612--example__keyword.org=
+produces a =20230515T085612--example__keyword.pdf=.  Any link to the
+=20230515T085612= will thus break: it does not honor Denote's
+expectation of finding unique identifiers.  This is not the fault of
+Denote: exporting is done by the user without Denote's involvement.
+
+Org Mode and Markdown use different approaches to exporting files.  No
+recommended method is available for plain text files as there is no
+standardised export functionality for this format (the user can always
+create a new note using the file type they want on a case-by-case
+basis: [[#h:887bdced-9686-4e80-906f-789e407f2e8f][Convenience commands for note creation]]).
+
+*** Export Denote notes with Org Mode
+:PROPERTIES:
+:CUSTOM_ID: h:67669d9d-17c3-45bd-8227-da57d8bc3b73
+:END:
+
+Org Mode has a built-in configurable export engine.  You can prevent
+duplicate identifiers when exporting manually for each exported file
+or by advising the Org export function.
+
+**** Manually configure Org export
+:PROPERTIES:
+:CUSTOM_ID: h:bf791e28-73e5-4ed8-88bc-e4e9b3ebaedb
+:END:
+
+Insert =#+export_file_name: FILENAME= in the front matter before
+exporting to force a filename called whatever the value of =FILENAME=
+is.  The =FILENAME= does not specify the file type extension, such as
+=.pdf=.  This is up to the export engine.  For example, a Denote note
+with a complete file name of =20230515T085612--example__keyword.org=
+and a front matter entry of =#+export_file_name: hello= will be
+exported as =hello.pdf=.
+
+The advantage of this manual method is that it gives the user full
+control over the resulting file name.  The disadvantage is that it
+depends on the user's behaviour.  Forgetting to add a new name can
+lead to duplicate identifiers, as already noted in the introduction to
+this section ([[#h:4a8c4546-26b3-4195-8b2c-b08a519986a4][Export Denote notes]]).
+
+**** Automatically store Org exports in another folder
+:PROPERTIES:
+:CUSTOM_ID: h:7a61a370-78e5-42a1-9650-98fee140723f
+:END:
+
+It is possible to automatically place all exports in another folder by
+making Org's function ~org-export-output-file-name~ create the target
+directory if needed and move the exported file there.  Remember that
+advising Elisp code must be handled with care, as it might break the
+original function in subtle ways.
+
+#+begin_src emacs-lisp
+(defvar my-org-export-output-directory-prefix "./export_"
+  "Prefix of directory used for org-mode export.
+
+The single dot means that the directory is created on the same
+level as the one where the Org file that performs the exporting
+is.  Use two dots to place the directory on a level above the
+current one.
+
+If this directory is part of `denote-directory', make sure it is
+not read by Denote.  See `denote-excluded-directories-regexp'.
+This way there will be no known duplicate Denote identifiers
+produced by the Org export mechanism.")
+
+(defun my-org-export-create-directory (fn extension &rest args)
+  "Move Org export file to its appropriate directory.
+
+Append the file type EXTENSION of the exported file to
+`my-org-export-output-directory-prefix' and, if absent, create a
+directory named accordingly.
+
+Install this as advice around `org-export-output-file-name'.  The
+EXTENSION is supplied by that function.  ARGS are its remaining
+arguments."
+  (let ((export-dir (format "%s%s" my-org-export-output-directory-prefix extension)))
+    (unless (file-directory-p export-dir)
+      (make-directory export-dir)))
+  (apply fn extension args))
+
+(advice-add #'org-export-output-file-name :around #'my-org-export-create-directory)
+#+end_src
+
+The target export directory should not be a subdirectory of
+~denote-directory~, as that will result in duplicate identifiers.
+Exclude it with the ~denote-excluded-directories-regexp~ user option
+([[#h:8458f716-f9c2-4888-824b-2bf01cc5850a][Exclude certain directories from all operations]]).
+
+[ NOTE: I (Protesilaos) am not a LaTeX user and cannot test the
+  following. ]
+
+Using a different directory will require some additional configuration
+when exporting using LaTeX.  The export folder cannot be inside the
+path of the ~denote-directory~ to prevent Denote from recognising it
+as an attachment:
+<https://emacs.stackexchange.com/questions/45751/org-export-to-different-directory>.
+
+**** Org Mode Publishing
+:PROPERTIES:
+:CUSTOM_ID: h:2f3451ed-2fc4-4f36-bcf2-112939963e20
+:END:
+
+Org Mode also has a publishing tool for exporting a collection of
+files. Some user might apply this approach to convert their note
+collection to a public or private website.
+
+The ~org-publish-project-alist~ variable drives the publishing
+process, including the publishing directory.
+
+The publishing directory should not be a subdirectory of
+~denote-directory~, as that will result in duplicate identifiers.
+Exclude it with the ~denote-excluded-directories-regexp~ user option
+([[#h:8458f716-f9c2-4888-824b-2bf01cc5850a][Exclude certain directories from all operations]]).
+
+*** Export Denote notes with Markdown
+:PROPERTIES:
+:CUSTOM_ID: h:44c6a34a-e9ad-4f43-a24f-12f2c5a8467e
+:END:
+
+Exporting from Markdown requires an external processor (e.g.,
+Markdown.pl, Pandoc, or MultiMarkdown).  The ~markdown-command~
+variable defines the command line used in export, for example:
+
+#+begin_src emacs-lisp
+(setq markdown-command "multimarkdown")
+#+end_src
+
+The export process thus occurs outside of Emacs.  Users need to read
+the documentation of their preferred processor to prevent the creation
+of duplicate Denote identifiers.
+
+* Installation
+:PROPERTIES:
+:CUSTOM_ID: h:f3bdac2c-4704-4a51-948c-a789a2589790
+:END:
+#+cindex: Installation instructions
+
+** GNU ELPA package
+:PROPERTIES:
+:CUSTOM_ID: h:42953f87-82bd-43ec-ab99-22b1e22955e7
+:END:
+
+The package is available as =denote=.  Simply do:
+
+: M-x package-refresh-contents
+: M-x package-install
+
+And search for it.
+
+GNU ELPA provides the latest stable release.  Those who prefer to follow
+the development process in order to report bugs or suggest changes, can
+use the version of the package from the GNU-devel ELPA archive.  Read:
+https://protesilaos.com/codelog/2022-05-13-emacs-elpa-devel/.
+
+** Manual installation
+:PROPERTIES:
+:CUSTOM_ID: h:d397712c-c8c0-4cfa-ad1a-ef28cf78d1f0
+:END:
+
+Assuming your Emacs files are found in =~/.emacs.d/=, execute the
+following commands in a shell prompt:
+
+#+begin_src sh
+cd ~/.emacs.d
+
+# Create a directory for manually-installed packages
+mkdir manual-packages
+
+# Go to the new directory
+cd manual-packages
+
+# Clone this repo, naming it "denote"
+git clone https://git.sr.ht/~protesilaos/denote denote
+#+end_src
+
+Finally, in your =init.el= (or equivalent) evaluate this:
+
+#+begin_src emacs-lisp
+;; Make Elisp files in that directory available to the user.
+(add-to-list 'load-path "~/.emacs.d/manual-packages/denote")
+#+end_src
+
+Everything is in place to set up the package.
+
+* Sample configuration
+:PROPERTIES:
+:CUSTOM_ID: h:5d16932d-4f7b-493d-8e6a-e5c396b15fd6
+:END:
+#+cindex: Package configuration
+
+#+begin_src emacs-lisp
+(require 'denote)
+
+;; Remember to check the doc strings of those variables.
+(setq denote-directory (expand-file-name "~/Documents/notes/"))
+(setq denote-known-keywords '("emacs" "philosophy" "politics" "economics"))
+(setq denote-infer-keywords t)
+(setq denote-sort-keywords t)
+(setq denote-file-type nil) ; Org is the default, set others here
+(setq denote-prompts '(title keywords))
+(setq denote-excluded-directories-regexp nil)
+(setq denote-excluded-keywords-regexp nil)
+
+;; Pick dates, where relevant, with Org's advanced interface:
+(setq denote-date-prompt-use-org-read-date t)
+
+
+;; Read this manual for how to specify `denote-templates'.  We do not
+;; include an example here to avoid potential confusion.
+
+
+;; We do not allow multi-word keywords by default.  The author's
+;; personal preference is for single-word keywords for a more rigid
+;; workflow.
+(setq denote-allow-multi-word-keywords t)
+
+(setq denote-date-format nil) ; read doc string
+
+;; By default, we do not show the context of links.  We just display
+;; file names.  This provides a more informative view.
+(setq denote-backlinks-show-context t)
+
+;; Also see `denote-link-backlinks-display-buffer-action' which is a bit
+;; advanced.
+
+;; If you use Markdown or plain text files (Org renders links as buttons
+;; right away)
+(add-hook 'find-file-hook #'denote-link-buttonize-buffer)
+
+;; We use different ways to specify a path for demo purposes.
+(setq denote-dired-directories
+      (list denote-directory
+            (thread-last denote-directory (expand-file-name "attachments"))
+            (expand-file-name "~/Documents/books")))
+
+;; Generic (great if you rename files Denote-style in lots of places):
+;; (add-hook 'dired-mode-hook #'denote-dired-mode)
+;;
+;; OR if only want it in `denote-dired-directories':
+(add-hook 'dired-mode-hook #'denote-dired-mode-in-directories)
+
+;; Here is a custom, user-level command from one of the examples we
+;; showed in this manual.  We define it here and add it to a key binding
+;; below.
+(defun my-denote-journal ()
+  "Create an entry tagged 'journal' with the date as its title.
+If a journal for the current day exists, visit it.  If multiple
+entries exist, prompt with completion for a choice between them.
+Else create a new file."
+  (interactive)
+  (let* ((today (format-time-string "%A %e %B %Y"))
+         (string (denote-sluggify today))
+         (files (denote-directory-files-matching-regexp string)))
+    (cond
+     ((> (length files) 1)
+      (find-file (completing-read "Select file: " files nil :require-match)))
+     (files
+      (find-file (car files)))
+     (t
+      (denote
+       today
+       '("journal"))))))
+
+;; Denote DOES NOT define any key bindings.  This is for the user to
+;; decide.  For example:
+(let ((map global-map))
+  (define-key map (kbd "C-c n j") #'my-denote-journal) ; our custom command
+  (define-key map (kbd "C-c n n") #'denote)
+  (define-key map (kbd "C-c n N") #'denote-type)
+  (define-key map (kbd "C-c n d") #'denote-date)
+  (define-key map (kbd "C-c n z") #'denote-signature) ; "zettelkasten" mnemonic
+  (define-key map (kbd "C-c n s") #'denote-subdirectory)
+  (define-key map (kbd "C-c n t") #'denote-template)
+  ;; If you intend to use Denote with a variety of file types, it is
+  ;; easier to bind the link-related commands to the `global-map', as
+  ;; shown here.  Otherwise follow the same pattern for `org-mode-map',
+  ;; `markdown-mode-map', and/or `text-mode-map'.
+  (define-key map (kbd "C-c n i") #'denote-link) ; "insert" mnemonic
+  (define-key map (kbd "C-c n I") #'denote-add-links)
+  (define-key map (kbd "C-c n b") #'denote-backlinks)
+  (define-key map (kbd "C-c n f f") #'denote-find-link)
+  (define-key map (kbd "C-c n f b") #'denote-find-backlink)
+  ;; Note that `denote-rename-file' can work from any context, not just
+  ;; Dired bufffers.  That is why we bind it here to the `global-map'.
+  (define-key map (kbd "C-c n r") #'denote-rename-file)
+  (define-key map (kbd "C-c n R") #'denote-rename-file-using-front-matter))
+
+;; Key bindings specifically for Dired.
+(let ((map dired-mode-map))
+  (define-key map (kbd "C-c C-d C-i") #'denote-link-dired-marked-notes)
+  (define-key map (kbd "C-c C-d C-r") #'denote-dired-rename-marked-files)
+  (define-key map (kbd "C-c C-d C-R") #'denote-dired-rename-marked-files-using-front-matter))
+
+(with-eval-after-load 'org-capture
+  (setq denote-org-capture-specifiers "%l\n%i\n%?")
+  (add-to-list 'org-capture-templates
+               '("n" "New note (with denote.el)" plain
+                 (file denote-last-path)
+                 #'denote-org-capture
+                 :no-save t
+                 :immediate-finish nil
+                 :kill-buffer t
+                 :jump-to-captured t)))
+
+;; Also check the commands `denote-link-after-creating',
+;; `denote-link-or-create'.  You may want to bind them to keys as well.
+
+
+;; If you want to have Denote commands available via a right click
+;; context menu, use the following and then enable
+;; `context-menu-mode'.
+(add-hook 'context-menu-functions #'denote-context-menu)
+#+end_src
+
+* For developers or advanced users
+:PROPERTIES:
+:CUSTOM_ID: h:c916d8c5-540a-409f-b780-6ccbd90e088e
+:END:
+
+Denote is in a stable state and can be relied upon as the basis for
+custom extensions.  Further below is a list with the functions or
+variables we provide for public usage.  Those are in addition to all
+user options and commands that are already documented in the various
+sections of this manual.
+
+In this context "public" is any form with single hyphens in its symbol,
+such as ~denote-directory-files~.  We expressly support those, meaning
+that we consider them reliable and commit to documenting any changes in
+their particularities (such as through ~make-obsolete~, a record in the
+change log, a blog post on the maintainer's website, and the like).
+
+By contradistinction, a "private" form is declared with two hyphens in
+its symbol such as ~denote--file-extension~.  Do not use those as we
+might change them without further notice.
+
+#+vindex: denote-id-format
++ Variable ~denote-id-format~ :: Format of ID prefix of a note's
+  filename.  The note's ID is derived from the date and time of its
+  creation ([[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]]).
+
+#+vindex: denote-id-regexp
++ Variable ~denote-id-regexp~ :: Regular expression to match
+  ~denote-id-format~.
+
+#+vindex: denote-signature-regexp
++ Variable ~denote-signature-regexp~ :: Regular expression to match
+  the =SIGNATURE= field in a file name.
+
+#+vindex: denote-title-regexp
++ Variable ~denote-title-regexp~ :: Regular expression to match the
+  =TITLE= field in a file name ([[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]]).
+
+#+vindex: denote-keywords-regexp
++ Variable ~denote-keywords-regexp~ :: Regular expression to match the
+  =KEYWORDS= field in a file name ([[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]]).
+
+#+vindex: denote-excluded-punctuation-regexp
++ Variable ~denote-excluded-punctuation-regexp~ :: Punctionation that
+  is removed from file names.  We consider those characters illegal
+  for our purposes.
+
+#+vindex: denote-excluded-punctuation-extra-regexp
++ Variable ~denote-excluded-punctuation-extra-regexp~ :: Additional
+  punctuation that is removed from file names.  This variable is for
+  advanced users who need to extend the ~denote-excluded-punctuation-regexp~.
+  Once we have a better understanding of what we should be omitting,
+  we will update things accordingly.
+
+#+findex: denote-file-is-note-p
++ Function ~denote-file-is-note-p~ :: Return non-nil if =FILE= is an
+  actual Denote note.  For our purposes, a note must not be a
+  directory, must satisfy ~file-regular-p~, its path must be part of
+  the variable ~denote-directory~, it must have a Denote identifier in
+  its name, and use one of the extensions implied by
+  ~denote-file-type~.
+
+#+findex: denote-file-has-identifier-p
++ Function ~denote-file-has-identifier-p~ :: Return non-nil if =FILE=
+  has a Denote identifier.
+
+#+findex: denote-file-has-signature-p
++ Function ~denote-file-has-signature-p~ :: Return non-nil if =FILE=
+  has a signature.
+
+#+findex: denote-file-has-supported-extension-p
++ Function ~denote-file-has-supported-extension-p~ :: Return non-nil
+  if =FILE= has supported extension.  Also account for the possibility
+  of an added =.gpg= suffix. Supported extensions are those implied by
+  ~denote-file-type~.
+
+#+findex: denote-file-is-writable-and-supported-p
++ Function ~denote-file-is-writable-and-supported-p~ :: Return non-nil
+  if =FILE= is writable and has supported extension.
+
+#+findex: denote-file-type-extensions
++ Function ~denote-file-type-extensions~ :: Return all file type
+  extensions in ~denote-file-types~.
+
+#+variable: denote-encryption-file-extensions
++ Variable ~denote-encryption-file-extensions~ :: List of strings
+  specifying file extensions for encryption.
+
+#+function: denote-file-type-extensions-with-encryption
++ Function ~denote-file-type-extensions-with-encryption~ :: Derive
+  ~denote-file-type-extensions~ plus ~denote-encryption-file-extensions~.
+  
+#+findex: denote-keywords
++ Function ~denote-keywords~ :: Return appropriate list of keyword
+  candidates.  If ~denote-infer-keywords~ is non-nil, infer keywords
+  from existing notes and combine them into a list with
+  ~denote-known-keywords~.  Else use only the latter set of keywords
+  ([[#h:6a92a8b5-d766-42cc-8e5b-8dc255466a23][Standard note creation]]).
+
+#+findex: denote-keywords-sort
++ Function ~denote-keywords-sort~ :: Sort =KEYWORDS= if
+  ~denote-sort-keywords~ is non-nil.  =KEYWORDS= is a list of strings,
+  per ~denote-keywords-prompt~.
+
+#+findex: denote-directory
++ Function ~denote-directory~ :: Return path of the variable
+  ~denote-directory~ as a proper directory, also because it accepts a
+  directory-local value for what we internally refer to as "silos"
+  ([[#h:15719799-a5ff-4e9a-9f10-4ca03ef8f6c5][Maintain separate directories for notes]]).  Custom Lisp code can
+  ~let~ bind the value of the variable ~denote-user-enforced-denote-directory~
+  to override what this function returns.
+  
+#+findex: denote-directory-files
++ Function ~denote-directory-files~ :: Return list of absolute file
+  paths in variable ~denote-directory~.  Files only need to have an
+  identifier.  The return value may thus include file types that are
+  not implied by ~denote-file-type~. To limit the return value to text
+  files, use the function ~denote-directory-text-only-files~.
+  Remember that the ~denote-directory~ accepts a directory-local value
+  ([[#h:15719799-a5ff-4e9a-9f10-4ca03ef8f6c5][Maintain separate directories for notes]]).
+
+#+findex: denote-directory-text-only-files
++ Function ~denote-directory-text-only-files~ :: Return list of text
+  files in variable ~denote-directory~.  Filter
+  ~denote-directory-files~ using ~denote-file-is-note-p~.
+
+#+findex: denote-directory-subdirectories
++ Function ~denote-directory-subdirectories~ :: Return list of
+  subdirectories in variable ~denote-directory~. Omit dotfiles (such
+  as .git) unconditionally.  Also exclude whatever matches
+  ~denote-excluded-directories-regexp~.  Note that the
+  ~denote-directory~ accepts a directory-local value for what we call
+  "silos" ([[#h:15719799-a5ff-4e9a-9f10-4ca03ef8f6c5][Maintain separate directories for notes]]).
+
+#+findex: denote-directory-files-matching-regexp
++ Function ~denote-directory-files-matching-regexp~ :: Return list of
+  files matching =REGEXP= in ~denote-directory-files~.
+
+#+findex: denote-file-name-relative-to-denote-directory
++ Function ~denote-file-name-relative-to-denote-directory~ :: Return
+  name of =FILE= relative to the variable ~denote-directory~.  =FILE=
+  must be an absolute path.
+
+#+findex: denote-get-path-by-id
++ Function ~denote-get-path-by-id~ :: Return absolute path of =ID=
+  string in ~denote-directory-files~.
+
+#+findex: denote-barf-duplicate-id
++ Function ~denote-barf-duplicate-id~ :: Throw a ~user-error~ if
+  =IDENTIFIER= already exists.
+
+#+findex: denote-sluggify
++ Function ~denote-sluggify~ :: Make =STR= an appropriate slug for
+  file names and related ([[#h:ae8b19a1-7f67-4258-96b3-370a72c43f4e][Sluggified title and keywords]]).
+
+#+findex: denote-sluggify-and-join
++ Function ~denote-sluggify-and-join~ :: Sluggify =STR= while joining
+  separate words.
+
+#+findex: denote-desluggify
++ Function ~denote-desluggify~ :: Upcase first char in =STR= and
+  dehyphenate =STR=, inverting ~denote-sluggify~.  Basically, convert
+  =this-is-a-test= to =This is a test=.
+
+#+findex: denote-sluggify-signature
++ Function ~denote-sluggify-signature~ :: Make =STR= an appropriate
+  slug for signatures.
+
+#+findex: denote-sluggify-keywords
++ Function ~denote-sluggify-keywords~ :: Sluggify =KEYWORDS=, which is
+  a list of strings ([[#h:ae8b19a1-7f67-4258-96b3-370a72c43f4e][Sluggified title and keywords]]).
+
+#+findex: denote-filetype-heuristics
++ Function ~denote-filetype-heuristics~ :: Return likely file type of
+  =FILE=.  Use the file extension to detect the file type of the file.
+
+  If more than one file type correspond to this file extension, use the
+  first file type for which the key-title-kegexp matches in the file or,
+  if none matches, use the first type with this file extension in
+  ~denote-file-type~.
+
+  If no file types in ~denote-file-types~ has the file extension, the
+  file type is assumed to be the first of ~denote-file-types~.
+
+#+findex: denote-format-file-name
++ Function ~denote-format-file-name~ :: Format file name.  =PATH=,
+  =ID=, =KEYWORDS=, =TITLE-SLUG= are expected to be supplied by
+  ~denote~ or equivalent: they will all be converted into a single
+  string.  =EXTENSION= is the file type extension, as a string.
+
+#+findex: denote-extract-keywords-from-path
++ Function ~denote-extract-keywords-from-path~ :: Extract keywords
+  from =PATH= and return them as a list of strings.  =PATH= must be a
+  Denote-style file name where keywords are prefixed with an
+  underscore.  If =PATH= has no such keywords, which is possible,
+  return nil ([[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]]).
+
+#+findex: denote-extract-id-from-string
++ Function ~denote-extract-id-from-string~ :: Return existing Denote
+  identifier in =STRING=, else nil.
+
+#+findex: denote-retrieve-filename-identifier
++ Function ~denote-retrieve-filename-identifier~ :: Extract identifier
+  from =FILE= name.  To return an existing identifier or create a new
+  one, refer to the ~denote-retrieve-or-create-file-identifier~
+  function.
+
+#+findex: denote-retrieve-filename-signature
++ Function ~denote-retrieve-filename-signature~ :: Extract signature
+  from =FILE= name, if present, else return nil.
+
+#+findex: denote-retrieve-or-create-file-identifier
++ Function ~denote-retrieve-or-create-file-identifier~ :: Return
+  =FILE= identifier, generating one if appropriate.  The conditions
+  are as follows:
+
+  - If =FILE= has an identifier, return it.
+
+  - If =FILE= does not have an identifier and optional =DATE= is
+    non-nil, invoke ~denote-prompt-for-date-return-id~.
+
+  - If =FILE= does not have an identifier and DATE is nil, use the
+    file attributes to determine the last modified date and format it
+    as an identifier.
+
+  - As a fallback, derive an identifier from the current time.
+  
+  With optional =FILES= as a list of file names, test that the
+  identifier is unique among them.
+
+  With optional =FILES= as non-nil, test that the identifier is unique
+  among all files and buffers in variable ~denote-directory~.
+
+  To only return an existing identifier, refer to the function
+  ~denote-retrieve-filename-identifier~.
+
+#+findex: denote-retrieve-filename-title
++ Function ~denote-retrieve-filename-title~ :: Extract title from
+  =FILE= name, else return ~file-name-base~.  Run ~denote-desluggify~
+  on the title if the extraction is successful.
+
+#+findex: denote-retrieve-title-value
++ Function ~denote-retrieve-title-value~ :: Return title value from
+  =FILE= front matter per =FILE-TYPE=.
+
+#+findex: denote-retrieve-title-line
++ Function ~denote-retrieve-title-line~ :: Return title line from
+  =FILE= front matter per =FILE-TYPE=.
+
+#+findex: denote-retrieve-keywords-value
++ Function ~denote-retrieve-keywords-value~ :: Return keywords value
+  from =FILE= front matter per =FILE-TYPE=.
+
+#+findex: denote-retrieve-keywords-line
++ Function ~denote-retrieve-keywords-line~ :: Return keywords line
+  from =FILE= front matter per =FILE-TYPE=.
+
+#+findex: denote-signature-prompt
++ Function ~denote-signature-prompt~ :: Prompt for signature
+  string.
+
+#+findex: denote-file-prompt
++ Function ~denote-file-prompt~ :: Prompt for file with identifier in
+  variable ~denote-directory~.  With optional =INITIAL-TEXT=, use it
+  to prepopulate the minibuffer.
+
+#+findex: denote-keywords-prompt
++ Function ~denote-keywords-prompt~ :: Prompt for one or more
+  keywords.  In the case of multiple entries, those are separated by
+  the ~crm-sepator~, which typically is a comma.  In such a scenario,
+  the output is sorted with ~string-lessp~.  To sort the return value,
+  use ~denote-keywords-sort~.
+
+#+findex: denote-title-prompt
++ Function ~denote-title-prompt~ :: Read file title for ~denote~.
+  With optional =DEFAULT-TITLE= use it as the default value.
+
+#+findex: denote-file-type-prompt
++ Function ~denote-file-type-prompt~ :: Prompt for ~denote-file-type~.
+  Note that a non-nil value other than ~text~, ~markdown-yaml~, and
+  ~markdown-toml~ falls back to an Org file type.  We use ~org~ here
+  for clarity.
+
+#+findex: denote-date-prompt
++ Function ~denote-date-prompt~ :: Prompt for date, expecting
+  =YYYY-MM-DD= or that plus =HH:MM= (or even =HH:MM:SS=).  Use Org's
+  more advanced date selection utility if the user option
+  ~denote-date-prompt-use-org-read-date~ is non-nil.  It requires Org
+  ([[#h:e7ef08d6-af1b-4ab3-bb00-494a653e6d63][The denote-date-prompt-use-org-read-date option]]).
+
+#+findex: denote-prompt-for-date-return-id
++ Function ~denote-prompt-for-date-return-id~ :: Use
+  ~denote-date-prompt~ and return it as ~denote-id-format~.
+
+#+findex: denote-template-prompt
++ Function ~denote-template-prompt~ :: Prompt for template key in
+  ~denote-templates~ and return its value.
+
+#+findex: denote-subdirectory-prompt
++ Function ~denote-subdirectory-prompt~ :: Prompt for subdirectory of
+  the variable ~denote-directory~.  The table uses the ~file~
+  completion category (so it works with packages such as ~marginalia~
+  and ~embark~).
+
+#+findex: denote-rename-file-prompt
++ Function ~denote-rename-file-prompt~ :: Prompt to rename file named
+  =OLD-NAME= to =NEW-NAME=.
+
+#+findex: denote-rename-file-and-buffer
++ Function ~denote-rename-file-and-buffer~ :: Rename file named
+  =OLD-NAME= to =NEW-NAME=, updating buffer name.
+
+#+findex: denote-rewrite-front-matter
++ Function ~denote-rewrite-front-matter~ :: Rewrite front matter of
+  note after ~denote-rename-file~ (or related) The =FILE=, =TITLE=,
+  =KEYWORDS=, and =FILE-TYPE= arguments are given by the renaming
+  command and are used to construct new front matter values if
+  appropriate.
+
+#+findex: denote-rewrite-keywords
++ Function ~denote-rewrite-keywords~ :: Rewrite =KEYWORDS= in =FILE=
+  outright according to =FILE-TYPE=.  Do the same as
+  ~denote-rewrite-front-matter~ for keywords, but do not ask for
+  confirmation.  This is for use in ~denote-keywords-add~,
+  ~denote-keywords-remove~, ~denote-dired-rename-marked-files~, or
+  related.
+
+#+findex: denote-update-dired-buffers
++ Function ~denote-update-dired-buffers~ :: Update Dired buffers of
+  variable ~denote-directory~.  Note that the ~denote-directory~
+  accepts a directory-local value for what we internally refer to as
+  "silos" ([[#h:15719799-a5ff-4e9a-9f10-4ca03ef8f6c5][Maintain separate directories for notes]]).
+
+#+vindex: denote-file-types
++ Variable ~denote-file-types~ :: Alist of ~denote-file-type~ and
+  their format properties.
+
+  Each element is of the form =(SYMBOL PROPERTY-LIST)=.  =SYMBOL= is
+  one of those specified in ~denote-file-type~ or an arbitrary symbol
+  that defines a new file type.
+
+  =PROPERTY-LIST= is a plist that consists of the following elements:
+
+  1. =:extension= is a string with the file extension including the
+     period.
+
+  2. =:date-function= is a function that can format a date.  See the
+     functions ~denote--date-iso-8601~, ~denote--date-rfc3339~, and
+     ~denote--date-org-timestamp~.
+
+  3. =:front-matter= is either a string passed to ~format~ or a
+     variable holding such a string.  The ~format~ function accepts
+     four arguments, which come from ~denote~ in this order: =TITLE=,
+     =DATE=, =KEYWORDS=, =IDENTIFIER=.  Read the doc string of
+     ~format~ on how to reorder arguments.
+
+  4. =:title-key-regexp= is a regular expression that is used to
+     retrieve the title line in a file.  The first line matching this
+     regexp is considered the title line.
+
+  5. =:title-value-function= is the function used to format the raw
+     title string for inclusion in the front matter (e.g. to surround
+     it with quotes).  Use the ~identity~ function if no further
+     processing is required.
+
+  6. =:title-value-reverse-function= is the function used to retrieve
+     the raw title string from the front matter.  It performs the
+     reverse of =:title-value-function=.
+
+  7. =:keywords-key-regexp= is a regular expression used to retrieve
+     the keywords' line in the file.  The first line matching this
+     regexp is considered the keywords' line.
+
+  8. =:keywords-value-function= is the function used to format the
+     keywords' list of strings as a single string, with appropriate
+     delimiters, for inclusion in the front matter.
+
+  9. =:keywords-value-reverse-function= is the function used to retrieve
+     the keywords' value from the front matter.  It performs the reverse
+     of the =:keywords-value-function=.
+
+  10. =:link= is a string, or variable holding a string, that
+      specifies the format of a link.  See the variables
+      ~denote-org-link-format~, ~denote-md-link-format~.
+
+  11. =:link-in-context-regexp= is a regular expression that is used
+      to match the aforementioned link format.  See the variables
+      ~denote-org-link-in-context-regexp~, ~denote-md-link-in-context-regexp~.
+
+  If ~denote-file-type~ is nil, use the first element of this list for
+  new note creation.  The default is ~org~.
+
+#+vindex: denote-org-front-matter
++ Variable ~denote-org-front-matter~ :: Specifies the Org front
+  matter.  It is passed to ~format~ with arguments =TITLE=, =DATE=,
+  =KEYWORDS=, =ID= ([[#h:7f918854-5ed4-4139-821f-8ee9ba06ad15][Change the front matter format]])
+
+#+vindex: denote-yaml-front-matter
++ Variable ~denote-yaml-front-matter~ :: Specifies the YAML (Markdown)
+  front matter.  It is passed to ~format~ with arguments =TITLE=,
+  =DATE=, =KEYWORDS=, =ID= ([[#h:7f918854-5ed4-4139-821f-8ee9ba06ad15][Change the front matter format]])
+
+#+vindex: denote-toml-front-matter
++ Variable ~denote-toml-front-matter~ :: Specifies the TOML (Markdown)
+  front matter.  It is passed to ~format~ with arguments =TITLE=,
+  =DATE=, =KEYWORDS=, =ID= ([[#h:7f918854-5ed4-4139-821f-8ee9ba06ad15][Change the front matter format]])
+
+#+vindex: denote-text-front-matter
++ Variable ~denote-text-front-matter~ :: Specifies the plain text
+  front matter.  It is passed to ~format~ with arguments =TITLE=,
+  =DATE=, =KEYWORDS=, =ID= ([[#h:7f918854-5ed4-4139-821f-8ee9ba06ad15][Change the front matter format]])
+
+#+vindex: denote-org-link-format
++ Variable ~denote-org-link-format~ :: Format of Org link to note.
+  The value is passed to ~format~ with =IDENTIFIER= and =TITLE=
+  arguments, in this order.  Also see ~denote-org-link-in-context-regexp~.
+
+#+vindex: denote-md-link-format
++ Variable ~denote-md-link-format~ :: Format of Markdown link to note.
+  The =%N$s= notation used in the default value is for ~format~ as the
+  supplied arguments are =IDENTIFIER= and =TITLE=, in this order.
+  Also see ~denote-md-link-in-context-regexp~.
+
+#+vindex: denote-id-only-link-format
++ Variable ~denote-id-only-link-format~ :: Format of identifier-only
+  link to note.  The value is passed to ~format~ with =IDENTIFIER= as
+  its sole argument.    Also see ~denote-id-only-link-in-context-regexp~.
+
+#+vindex: denote-org-link-in-context-regexp
++ Variable ~denote-org-link-in-context-regexp~ :: Regexp to match an
+  Org link in its context.  The format of such links is ~denote-org-link-format~.
+
+#+vindex: denote-md-link-in-context-regexp
++ Variable ~denote-md-link-in-context-regexp~ :: Regexp to match an
+  Markdown link in its context.  The format of such links is ~denote-md-link-format~.
+
+#+vindex: denote-id-only-link-in-context-regexp
++ Variable ~denote-id-only-link-in-context-regexp~ :: Regexp to match
+  an identifier-only link in its context.  The format of such links is
+  ~denote-id-only-link-format~.
+
+#+findex: denote-surround-with-quotes
++ Function ~denote-surround-with-quotes~ :: Surround string =S= with
+  quotes.  This can be used in ~denote-file-types~ to format front
+  mattter.
+
+#+findex: denote-date-org-timestamp
++ Function ~denote-date-org-timestamp~ :: Format =DATE= using the Org
+  inactive timestamp notation.
+
+#+findex: denote-date-rfc3339
++ Function ~denote-date-rfc3339~ :: Format =DATE= using the RFC3339
+  specification.
+
+#+findex: denote-date-iso-8601
++ Function ~denote-date-iso-8601~ :: Format =DATE= according to ISO
+  8601 standard.
+
+#+findex: denote-trim-whitespace
++ Function ~denote-trim-whitespace~ :: Trim whitespace around string
+  =S=.  This can be used in ~denote-file-types~ to format front
+  mattter.
+
+#+findex: denote-trim-whitespace-then-quotes
++ Function ~denote-trim-whitespace-then-quotes~ :: Trim whitespace
+  then quotes around string =S=.  This can be used in
+  ~denote-file-types~ to format front mattter.
+
+#+findex: denote-format-keywords-for-md-front-matter
++ Function ~denote-format-keywords-for-md-front-matter~ :: Format
+  front matter =KEYWORDS= for markdown file type.  =KEYWORDS= is a
+  list of strings.  Consult the ~denote-file-types~ for how this is
+  used.
+
+#+findex: denote-format-keywords-for-text-front-matter
++ Function ~denote-format-keywords-for-text-front-matter~ :: Format
+  front matter =KEYWORDS= for text file type.  =KEYWORDS= is a list of
+  strings.  Consult the ~denote-file-types~ for how this is used.
+
+#+findex: denote-format-keywords-for-org-front-matter
++ Function ~denote-format-keywords-for-org-front-matter~ :: Format
+  front matter =KEYWORDS= for org file type.  =KEYWORDS= is a list of
+  strings.  Consult the ~denote-file-types~ for how this is used.
+
+#+findex: denote-extract-keywords-from-front-matter
++ Function ~denote-extract-keywords-from-front-matter~ :: Format front
+  matter =KEYWORDS= for org file type.  =KEYWORDS= is a list of
+  strings.  Consult the ~denote-file-types~ for how this is used.
+
+#+findex: denote-link-return-links
++ Function ~denote-link-return-links~ :: Return list of links in
+  current or optional =FILE=.  Also see ~denote-link-return-backlinks~.
+
+#+findex: denote-link-return-backlinks
++ Function ~denote-link-return-backlinks~ :: Return list of links in
+  current or optional =FILE=.  Also see ~denote-link-return-links~.
+
+* Troubleshoot Denote in a pristine environment
+:PROPERTIES:
+:CUSTOM_ID: h:9c4467d5-6480-4681-80fb-cd9717bf8b3b
+:END:
+
+Sometimes we get reports on bugs that may not be actually caused by
+some error in the Denote code base.  To help gain insight into what
+the problem is, we need to be able to reproduce the issue in a minimum
+viable system.  Below is one way to achieve this.
+
+1. Find where your =denote.el= file is stored on your filesystem.
+
+2. Assuming you have already installed the package, one way to do this
+   is to invoke =M-x find-library= and search for ~denote~.  It will
+   take you to the source file.  There do =M-x eval-expression=, which
+   will bring up a minibuffer prompt.  At the prompt evaluate:
+
+#+begin_example emacs-lisp
+(kill-new (expand-file-name (buffer-file-name)))
+#+end_example
+
+3. The above will save the full file system path to your kill ring.
+
+4. In a terminal emulator or an =M-x shell= buffer execute:
+
+#+begin_example
+emacs -Q
+#+end_example
+
+5. This will open a new instance of Emacs in a pristine environment.
+   Only the default settings are loaded.
+
+6. In the =*scratch*= buffer of =emacs -Q=, add your configurations
+   like the following and try to reproduce the issue:
+
+#+begin_example emacs-lisp
+(require 'denote "/full/path/to/what/you/got/denote.el")
+
+;; Your configurations here
+#+end_example
+
+Then try to see if your problem still occurs.  If it does, then the
+fault is with Denote.  Otherwise there is something external to it
+that we need to account for.  Whatever the case, this exercise helps
+us get a better sense of the specifics.
+
+* Contributing
+:PROPERTIES:
+:CUSTOM_ID: h:1ebe4865-c001-4747-a6f2-0fe45aad71cd
+:END:
+
+Denote is a GNU ELPA package.  As such, any significant change to the
+code requires copyright assignment to the Free Software Foundation (more
+below).
+
+You do not need to be a programmer to contribute to this package.
+Sharing an idea or describing a workflow is equally helpful, as it
+teaches us something we may not know and might be able to cover either
+by extending Denote or expanding this manual ([[#h:044a6a0f-e382-4013-8279-8bf4e64e73c0][Things to do]]).  If you
+prefer to write a blog post, make sure you share it with us: we can add
+a section herein referencing all such articles.  Everyone gets
+acknowledged ([[#h:f8126820-3b59-49fa-bcc2-73bd60132bb9][Acknowledgements]]).  There is no such thing as an
+"insignificant contribution"---they all matter.
+
++ Package name (GNU ELPA): =denote=
++ Official manual: <https://protesilaos.com/emacs/denote>
++ Change log: <https://protesilaos.com/emacs/denote-changelog>
++ Git repo on SourceHut: <https://git.sr.ht/~protesilaos/denote>
+  - Mirrors:
+    + GitHub: <https://github.com/protesilaos/denote>
+    + GitLab: <https://gitlab.com/protesilaos/denote>
++ Mailing list: <https://lists.sr.ht/~protesilaos/denote>
+
+If our public media are not suitable, you are welcome to contact me
+(Protesilaos) in private: <https://protesilaos.com/contact>.
+
+Copyright assignment is a prerequisite to sharing code.  It is a simple
+process.  Check the request form below (please adapt it accordingly).
+You must write an email to the address mentioned in the form and then
+wait for the FSF to send you a legal agreement.  Sign the document and
+file it back to them.  This could all happen via email and take about a
+week.  You are encouraged to go through this process.  You only need to
+do it once.  It will allow you to make contributions to Emacs in
+general.
+
+#+begin_example text
+Please email the following information to assign@gnu.org, and we
+will send you the assignment form for your past and future changes.
+
+Please use your full legal name (in ASCII characters) as the subject
+line of the message.
+
+REQUEST: SEND FORM FOR PAST AND FUTURE CHANGES
+
+[What is the name of the program or package you're contributing to?]
+
+GNU Emacs
+
+[Did you copy any files or text written by someone else in these changes?
+Even if that material is free software, we need to know about it.]
+
+Copied a few snippets from the same files I edited.  Their author,
+Protesilaos Stavrou, has already assigned copyright to the Free Software
+Foundation.
+
+[Do you have an employer who might have a basis to claim to own
+your changes?  Do you attend a school which might make such a claim?]
+
+
+[For the copyright registration, what country are you a citizen of?]
+
+
+[What year were you born?]
+
+
+[Please write your email address here.]
+
+
+[Please write your postal address here.]
+
+
+
+
+
+[Which files have you changed so far, and which new files have you written
+so far?]
+
+#+end_example
+
+* Things to do
+:PROPERTIES:
+:CUSTOM_ID: h:044a6a0f-e382-4013-8279-8bf4e64e73c0
+:END:
+
+Denote should work well for what is described in this manual.  Though we
+can always do better.  This is a non-exhaustive list with some
+low-priority ideas you may want to help with ([[#h:1ebe4865-c001-4747-a6f2-0fe45aad71cd][Contributing]]).
+
+- Support mutually-exclusive sets of tags.  For example, a =home=
+  keyword would preclude =work=.  Personally, I am not a fan of such
+  arrangements as there may be a case where something applies to both
+  ends of this prefigured binary.  Though we can think about it.
+
+- Add command that expands the identifier in links to a full file name.
+  This would be useful for some sort of "export" operation where the
+  absolute file path is necessary and where the Denote linking mechanism
+  is not available.  Though this could be handled by the exporter, by
+  doing something like what ~denote-find-link~ does.
+
+- Add command that rewrites full names in links, if they are invalid.
+  This would complement the renaming mechanism.  Personally, I think old
+  titles in links are not a problem, because they show you what was true
+  at the time and are usually relevant to their context.  Again though,
+  it is an option worth exploring.
+
+- Ensure integration between =denote:= links and the =embark= package.
+  The idea is to allow Embark to understand the Denote buttons are links
+  to files and correctly infer the absolute path.  I am not sure what a
+  user would want to do with this, but maybe there are some interesting
+  possibilities.
+
+You are welcome to suggest more ideas.  If they do not broaden the scope
+of Denote, they can be added to denote.el.  Otherwise we might think of
+extensions to the core package.
+
+* Publications about Denote
+:PROPERTIES:
+:CUSTOM_ID: h:ca0c38f9-fa3e-4901-947e-1b589335781d
+:END:
+
+The Emacs community is putting Denote to great use.  This section
+includes publications that show how people configure their note-taking
+setup.  If you have a blog post, video, or configuration file about
+Denote, feel welcome to tell us about it ([[#h:1ebe4865-c001-4747-a6f2-0fe45aad71cd][Contributing]]).
+
++ David Wilson (SystemCrafters): /Generating a Blog Site from Denote
+  Entries/, 2022-09-09, <https://www.youtube.com/watch?v=5R7ad5xz5wo>
+
++ David Wilson (SystemCrafters): /Trying Out Prot's Denote, an Org
+  Roam Alternative?/, 2022-07-15, <https://www.youtube.com/watch?v=QcRY_rsX0yY>
+
++ Jack Baty: /Keeping my Org Agenda updated based on Denote keywords/,
+  2022-11-30, <https://baty.net/2022/keeping-my-org-agenda-updated>
+
++ Jeremy Friesen: /Denote Emacs Configuration/, 2022-10-02,
+  <https://takeonrules.com/2022/10/09/denote-emacs-configuration/>
+
++ Jeremy Friesen: /Exploring the Denote Emacs Package/, 2022-10-01,
+  <https://takeonrules.com/2022/10/01/exploring-the-denote-emacs-package/>
+
++ Jeremy Friesen: /Migration Plan for Org-Roam Notes to Denote/,
+  2022-10-02, <https://takeonrules.com/2022/10/02/migration-plan-for-org-roam-notes-to-denote/>
+
++ Jeremy Friesen: /Project Dispatch Menu with Org Mode Metadata,
+  Denote, and Transient/, 2022-11-19,
+  <https://takeonrules.com/2022/11/19/project-dispatch-menu-with-org-mode-metadata-denote-and-transient/>
+
++ Mohamed Suliman: /Managing a bibliography of BiBTeX entries with
+  Denote/, 2022-12-20, <https://www.scss.tcd.ie/~sulimanm/posts/denote-bibliography.html>
+
++ Peter Prevos: /Simulating Text Files with R to Test the Emacs Denote
+  Package/, 2022-07-28, <https://lucidmanager.org/productivity/testing-denote-package/>
+
++ Stefan Thesing: /Denote as a Zettelkasten/, 2023-03-02,
+  <https://www.thesing-online.de/blog/denote-as-a-zettelkasten>
+
++ Summer Emacs: /An explanation of how I use Emacs/, 2023-05-04,
+  <https://github.com/summeremacs/howiuseemacs/blob/main/full-explanation-of-how-i-use-emacs.org>
+
+* Alternatives to Denote
+:PROPERTIES:
+:CUSTOM_ID: h:dbb51a1b-90b8-48e8-953c-e2fb3e36981e
+:END:
+
+What follows is a list of Emacs packages for note-taking.  I
+(Protesilaos) have not used any of them, as I was manually applying my
+file-naming scheme beforehand and by the time those packages were
+available I was already hacking on the predecessor of Denote as a means
+of learning Emacs Lisp (a package which I called "Unassuming Sidenotes
+of Little Significance", aka "USLS" which is pronounced as "U-S-L-S" or
+"useless").  As such, I cannot comment at length on the differences
+between Denote and each of those packages, beside what I gather from
+their documentation.
+
++ [[https://github.com/org-roam/org-roam][org-roam]] :: The de facto standard in the Emacs milieu---and rightly
+  so!  It has a massive community, is featureful, and should be an
+  excellent companion to anyone who is invested in the Org ecosystem
+  and/or knows what "Roam" is (I don't).  It has been explained to me
+  that Org Roam uses a database to store a cache about your notes.  It
+  otherwise uses standard Org files.  The cache helps refer to the same
+  node through aliases which can provide lots of options.  Personally, I
+  follow a single-topic-per-note approach, so anything beyond that is
+  overkill.  If the database is only for a cache, then maybe that has no
+  downside, though I am careful with any kind of specialised program as
+  it creates a dependency.  If you ask me about database software in
+  particular, I have no idea how to use one, let alone debug it or
+  retrieve data from it if something goes awry (I could learn, but that
+  is beside the point).
+
++ [[https://github.com/localauthor/zk][zk (or zk.el)]] :: Reading its documentation makes me think that this is
+  Denote's sibling---the two projects have a lot of things in common,
+  including the preference to rely on plain files and standard tools.
+  The core difference is that Denote has a strict file-naming scheme.
+  Other differences in available features are, in principle, matters of
+  style or circumstance: both packages can have them.  As its initials
+  imply, ZK enables a zettelkasten-like workflow.  It does not enforce
+  it though, letting the user adapt the method to their needs and
+  requirements.
+
++ [[https://github.com/ymherklotz/emacs-zettelkasten][zettelkasten]] :: This is another one of Denote's relatives, at least
+  insofar as the goal of simplicity is concerned.  The major difference
+  is that according to its documentation "the name of the file that is
+  created is just a unique ID".  This is not consistent with our
+  file-naming scheme which is all about making sense of your files by
+  their name alone and being able to visually parse a listing of them
+  without any kind of specialised tool (e.g. =ls -l= or =ls -C= on the
+  command-line from inside the ~denote-directory~ give you a
+  human-readable set of files names, while =find * -maxdepth 0 -type f=
+  is another approach).
+
++ [[https://github.com/EFLS/zetteldeft][zetteldeft]] :: This is a zettelkasten note-taking system built on top
+  of the =deft= package.  Deft provides a search interface to a
+  directory, in this case the one holding the user's =zetteldeft= notes.
+  Denote has no such dependency and is not opinionated about how the
+  user prefers to search/access their notes: use Dired, Grep, the
+  =consult= package, or whatever else you already have set up for all
+  things Emacs, not just your notes.
+
+Searching through =M-x list-packages= for "zettel" brings up more
+matches.  =zetteldesk= is an extension to Org Roam and, as such, I
+cannot possibly know what Org Roam truly misses and what the added-value
+of this package is.  =neuron-mode= builds on top of an external program
+called =neuron=, which I have never used.
+
+Searching for "note" gives us a few more results.  =notes-mode= has
+precious little documentation and I cannot tell what it actually does
+(as I said in my presentation for LibrePlanet 2022, inadequate docs are
+a bug).  =side-notes= differs from what we try to do with Denote, as it
+basically gives you the means to record your thoughts about some other
+project you are working on and keep them on the side: so it and Denote
+should not be mutually exclusive.
+
+If I missed something, please let me know.
+
+** Alternative implementations and further reading
+:PROPERTIES:
+:CUSTOM_ID: h:188c0986-f2fa-444f-b493-5429356e75cf
+:END:
+
+This section covers blog posts and implementations from the Emacs
+community about the topic of note-taking and file organization.  They
+may refer to some of the packages covered in the previous section or
+provide their custom code ([[#h:dbb51a1b-90b8-48e8-953c-e2fb3e36981e][Alternatives to Denote]]).  The list is
+unsorted.
+
++ José Antonio Ortega Ruiz (aka "jao") explains a note-taking method
+  that is simple like Denote but differs in other ways.  An interesting
+  approach overall: https://jao.io/blog/simple-note-taking.html.
+
++ Jethro Kuan (the main =org-roam= developer) explains their note-taking
+  techniques: https://jethrokuan.github.io/org-roam-guide/.  Good ideas
+  all round, regardless of the package/code you choose to use.
+
++ Karl Voit's tools [[https://github.com/novoid/date2name][date2name]], [[https://github.com/novoid/filetags/][filetags]], [[https://github.com/novoid/appendfilename/][appendfilename]], and
+  [[https://github.com/novoid/move2archive][move2archive]] provide a Python-based implementation to organize
+  individual files which do not require Emacs.  His approach ([[https://karl-voit.at/managing-digital-photographs/][blog
+  post]] and his [[https://www.youtube.com/watch?v=rckSVmYCH90][presentation at GLT18]]) has been complemented by [[https://github.com/novoid/memacs][memacs]]
+  to process e.g., the date of creation of photographs, or the log of
+  a phone call in a format compatible to org.
+
+[ Development note: help expand this list. ]
+
+* Frequently Asked Questions
+:PROPERTIES:
+:CUSTOM_ID: h:da2944c6-cde6-4c65-8f2d-579305a159bb
+:END:
+
+I (Protesilaos) answer some questions I have received or might get.  It
+is assumed that you have read the rest of this manual: I will not go
+into the specifics of how Denote works.
+
+** Why develop Denote when PACKAGE already exists?
+:PROPERTIES:
+:CUSTOM_ID: h:b875450a-ae22-4899-ac23-c10fa9c279bb
+:END:
+
+I wrote Denote because I was using a variant of Denote's file-naming
+scheme before I was even an Emacs user (I switched to Emacs from
+Tmux+Vim+CLI in the summer of 2019).  I was originally inspired by
+Jekyll, the static site generator, which I started using for my website
+in 2016 (was on WordPress before).  Jekyll's files follow the
+=YYYY-MM-DD-TITLE.md= pattern.  I liked its efficiency relative to the
+unstructured mess I had before.  Eventually, I started using that scheme
+outside the confines of my website's source code.  Over time I refined
+it and here we are.
+
+Note-taking is something I take very seriously, as I am a prolific
+writer (just check my website, which only reveals the tip of the
+iceberg).  As such, I need a program that does exactly what I want and
+which I know how to extend.  I originally tried to use Org capture
+templates to create new files with a Denote-style file-naming scheme but
+never managed to achieve it.  Maybe because ~org-capture~ has some
+hard-coded assumptions or I simply am not competent enough to hack on
+core Org facilities.  Whatever the case, an alternative was in order.
+
+The existence of PACKAGE is never a good reason for me not to conduct my
+own experiments for recreational, educational, or practical purposes.
+When the question arises of "why not contribute to PACKAGE instead?" the
+answer is that without me experimenting in the first place, I would lack
+the skills for such a task.  Furthermore, contributing to another
+package does not guarantee I get what I want in terms of workflow.
+
+Whether you should use Denote or not is another matter altogether:
+choose whatever you want.
+
+** Why not rely exclusively on Org?
+:PROPERTIES:
+:CUSTOM_ID: h:b9831849-5c71-484e-b444-bac19cc13151
+:END:
+
+I think Org is one of Emacs' killer apps.  I also believe it is not the
+right tool for every job.  When I write notes, I want to focus on
+writing.  Nothing more.  I thus have no need for stuff like org-babel,
+scheduling to-do items, clocking time, and so on.  The more "mental
+dependencies" you add to your workflow, the heavier the burden you carry
+and the less focused you are on the task at hand: there is always that
+temptation to tweak the markup, tinker with some syntactic construct,
+obsess about what ought to be irrelevant to writing as such.
+
+In technical terms, I also am not fond of Org's code base (I understand
+why it is the way it is---just commenting on the fact).  Ever tried to
+read it?  You will routinely find functions that are tens-to-hundreds of
+lines long and have all sorts of special casing.  As I am not a
+programmer and only learnt to write Elisp through trial and error, I
+have no confidence in my ability to make Org do what I want at that
+level, hence =denote= instead of =org-denote= or something.
+
+Perhaps the master programmer is one who can deal with complexity and
+keep adding to it.  I am of the opposite view, as language---code
+included---is at its communicative best when it is clear and accessible.
+
+Make no mistake: I use Org for the agenda and also to write technical
+documentation that needs to be exported to various formats, including
+this very manual.
+
+** Why care about Unix tools when you use Emacs?
+:PROPERTIES:
+:CUSTOM_ID: h:da1e2469-8f04-450b-a379-a854efa80a36
+:END:
+
+My notes form part of my longer-term storage.  I do not want to have to
+rely on a special program to be able to read them or filter them.  Unix
+is universal, at least as far as I am concerned.
+
+Denote streamlines some tasks and makes things easier in general, which
+is consistent with how Emacs provides a layer of interactivity on top of
+Unix.  Still, Denote's utilities can, in principle, be implemented as
+POSIX shell scripts (minus the Emacs-specific parts like fontification
+in Dired or the buttonization of links).
+
+Portability matters.  For example, in the future I might own a
+smartphone, so I prefer not to require Emacs, Org, or some other
+executable to access my files on the go.
+
+Furthermore, I might want to share those files with someone.  If I make
+Emacs a requirement, I am limiting my circle to a handful of relatively
+advanced users.
+
+Please don't misinterpret this: I am using Emacs full-time for my
+computing and maintain a growing list of packages for it.  This is just
+me thinking long-term.
+
+** Why many small files instead of few large ones?
+:PROPERTIES:
+:CUSTOM_ID: h:7d2e7b8a-d484-4c1d-8688-17f70f242ad7
+:END:
+
+I have read that Org favours the latter method.  If true, I strongly
+disagree with it because of the implicit dependency it introduces and
+the way it favours machine-friendliness over human-readability in terms
+of accessing information.  Notes are long-term storage.  I might want to
+access them on (i) some device with limited features, (ii) print on
+paper, (iii) share with another person who is not a tech wizard.
+
+There are good arguments for few large files, but all either prioritize
+machine-friendliness or presuppose the use of sophisticated tools like
+Emacs+Org.
+
+Good luck using =less= on a generic TTY to read a file with a zillion
+words, headings, sub-headings, sub-sub-headings, property drawers, and
+other constructs!  You will not get the otherwise wonderful folding of
+headings the way you do in Emacs---do not take such features for
+granted.
+
+My point is that notes should be atomic to help the user---and
+potentially the user's family, friends, acquaintances---make sense of
+them in a wide range of scenaria.  The more program-agnostic your file
+is, the better for you and/or everyone else you might share your
+writings with.
+
+Human-readability means that we optimize for what matters to us.  If (a)
+you are the only one who will ever read your notes, (b) always have
+access to good software like Emacs+Org, (c) do not care about printing
+on paper, then Denote's model is not for you.  Maybe you need to tweak
+some ~org-capture~ template to append a new entry to one mega file (I do
+that for my Org agenda, by the way, as I explained before about using
+the right tool for the job).
+
+** Does Denote perform well at scale?
+:PROPERTIES:
+:CUSTOM_ID: h:863f812a-aac7-42ea-83b3-fbbdb58e08d7
+:END:
+
+Denote does not do anything fancy and has no special requirements: it
+uses standard tools to accomplish ordinary tasks.  If Emacs can cope
+with lots of files, then that is all you need to know: Denote will work.
+
+To put this to the test, Peter Prevos is running simulations with R that
+generate large volumes of notes.  You can read the technicalities here:
+<https://lucidmanager.org/productivity/testing-denote-package/>.
+Excerpt:
+
+#+begin_quote
+Using this code I generated ten thousands notes and used this to test
+the Denote package to see it if works at a large scale. This tests shows
+that Prot's approach is perfectly capable of working with thousands of
+notes.
+#+end_quote
+
+Of course, we are always prepared to make refinements to the code, where
+necessary, without compromising on the project's principles.
+
+** I add TODOs to my notes; will many files slow down the Org agenda?
+:PROPERTIES:
+:CUSTOM_ID: h:63c2f8d4-79ed-4c55-b3ef-e048a05802c0
+:END:
+
+Yes, many files will slow down the agenda due to how that works.  Org
+collects all files specified in the ~org-agenda-files~, searches through
+their contents for timestamped entries, and then loops through all days
+to determine where each entry belongs.  The more days and more files,
+the longer it takes to build the agenda.  Doing this with potentially
+hundreds of files will have a noticeable impact on performance.
+
+This is not a deficiency of Denote.  It happens with generic Org files.
+The way the agenda is built is heavily favoring the use of a single file
+that holds all your timestamped entries (or at least a few such files).
+Tens or hundreds of files are inefficient for this job.  Plus doing so
+has the side-effect of making Emacs open all those files, which you
+probably do not need.
+
+If you want my opinion though, be more forceful with the separation of
+concerns.  Decouple your knowledge base from your ephemeral to-do list:
+Denote (and others) can be used for the former, while you let standard
+Org work splendidly for the latter---that is what I do, anyway.
+
+Org has a powerful linking facility, whether you use ~org-store-link~ or
+do it via an ~org-capture~ template.  If you want a certain note to be
+associated with a task, just store the task in a single =tasks.org= (or
+however you name it) and link to the relevant context.
+
+Do not mix your knowledge base with your to-do items.  If you need help
+figuring out the specifics of this workflow, you are welcome to ask for
+help in our relevant channels ([[#h:1ebe4865-c001-4747-a6f2-0fe45aad71cd][Contributing]]).
+
+** I want to sort by last modified, why won't Denote let me?
+:PROPERTIES:
+:CUSTOM_ID: h:a7fd5e0a-78f7-434e-aa2e-e150479c16e2
+:END:
+
+Denote does not sort files and will not reinvent tools that handle such
+functionality.  This is the job of the file manager or command-line
+executable that lists files.
+
+I encourage you to read the manpage of the =ls= executable.  It will
+help you in general, while it applies to Emacs as well via Dired.  The
+gist is that you can update the =ls= flags that Dired uses on-the-fly:
+type =C-u M-x dired-sort-toggle-or-edit= (=C-u s= by default) and append
+=--sort=time= at the prompt.  To reverse the order, add the =-r= flag.
+The user option ~dired-listing-switches~ sets your default preference.
+
+There is also "virtual Dired" if you need something that cannot be
+done with Dired ([[#h:d35d8d41-f51b-4139-af8f-9c8cc508e35b][Use dired-virtual-mode for arbitrary file listings]]).
+
+** How do you handle the last modified case?
+:PROPERTIES:
+:CUSTOM_ID: h:764b5e87-cd22-4937-b5fc-af3892d6b3d8
+:END:
+
+Denote does not insert any meta data or heading pertaining to edits in
+the file.  I am of the view that these either do not scale well or are
+not descriptive enough.  Suppose you use a "lastmod" heading with a
+timestamp: which lines where edited and what did the change amount to?
+
+This is where an external program can be helpful.  Use a Version Control
+System, such as Git, to keep track of all your notes.  Every time you
+add a new file, record the addition.  Same for post-creation edits.
+Your VCS will let you review the history of those changes.  For
+instance, Emacs' built-in version control framework has a command that
+produces a log of changes for the current file: =M-x vc-print-log=,
+bound to =C-x v l= by default.  From there one can access the
+corresponding diff output (use =M-x describe-mode= (=C-h m=) in an
+unfamiliar buffer to learn more about it).  With Git in particular,
+Emacs users have the option of the all-round excellent =magit= package.
+
+In short: let Denote (or equivalent) create notes and link between them,
+the file manager organise and provide access to files, search programs
+deal with searching and narrowing, and version control software handle
+the tracking of changes.
+
+** Speed up backlinks' buffer creation?
+:PROPERTIES:
+:CUSTOM_ID: h:893eec49-d7be-4603-bcff-fcc247244011
+:END:
+
+Denote leverages the built-in =xref= library to search for the
+identifier of the current file and return any links to it.  For users
+of Emacs version 28 or higher, there exists a user option to specify
+the program that performs this search: ~xref-search-program~.  The
+default is =grep=, which can be slow, though one may opt for =ugrep=,
+=ripgrep=, or even specify something else (read the doc string of that
+user option for the details).
+
+Try either for these for better results:
+
+#+begin_src emacs-lisp
+(setq xref-search-program 'ripgrep)
+
+;; OR
+
+(setq xref-search-program 'ugrep)
+#+end_src
+
+To use whatever executable is available on your system, use something
+like this:
+
+#+begin_src emacs-lisp
+;; Prefer ripgrep, then ugrep, and fall back to regular grep.
+(setq xref-search-program
+      (cond
+       ((or (executable-find "ripgrep")
+            (executable-find "rg"))
+        'ripgrep)
+       ((executable-find "ugrep")
+        'ugrep)
+       (t
+        'grep)))
+#+end_src
+
+** Why do I get "Search failed with status 1" when I search for backlinks?
+:PROPERTIES:
+:CUSTOM_ID: h:42f6b07e-5956-469a-8294-17f9cf62eb2b
+:END:
+
+Denote uses [[info:emacs#Xref][Emacs' Xref]] to find backlinks.  Xref requires ~xargs~ and
+one of ~grep~ or ~ripgrep~, depending on your configuration.
+
+This is usually not an issue on *nix systems, but the necessary
+executables are not available on Windows Emacs distributions.  Please
+ensure that you have both ~xargs~ and either ~grep~ or ~ripgrep~
+available within your ~PATH~ environment variable.
+
+If you have ~git~ on Windows installed, then you may use the following
+code (adjust the git's installation path if necessary):
+#+begin_src emacs-lisp
+  (setenv "PATH" (concat (getenv "PATH") ";" "C:\\Program Files\\Git\\usr\\bin"))
+#+end_src
+
+* Acknowledgements
+:PROPERTIES:
+:CUSTOM_ID: h:f8126820-3b59-49fa-bcc2-73bd60132bb9
+:END:
+#+cindex: Contributors
+
+Denote is meant to be a collective effort.  Every bit of help matters.
+
++ Author/maintainer :: Protesilaos Stavrou.
+
++ Contributions to code or the manual :: Abin Simon, Adam Růžička,
+  Alan Schmitt, Benjamin Kästner, Bruno Boal, Charanjit Singh, Clemens
+  Radermacher, Colin McLear, Damien Cassou, Eduardo Grajeda, Elias
+  Storms, Eshel Yaron, Florian, Graham Marlow, Hilde Rhyne, Jack Baty,
+  Jean-Philippe Gagné Guay, Jürgen Hötzel, Kaushal Modi, Kai von
+  Fintel, Kyle Meyer, Marc Fargas, Matthew Lemon, Noboru Ota (nobiot),
+  Norwid Behrnd, Peter Prevos, Philip Kaludercic, Quiliro Ordóñez,
+  Stefan Monnier, Stefan Thesing, Thibaut Benjamin, Tomasz Hołubowicz,
+  Vedang Manerikar, relict007.
+
++ Ideas and/or user feedback :: Abin Simon, Aditya Yadav, Alan
+  Schmitt, Alfredo Borrás, Ashton Wiersdorf, Benjamin Kästner, Colin
+  McLear, Damien Cassou, Elias Storms, Federico Stilman, Florian,
+  Frank Ehmsen, Guo Yong, Hanspeter Gisler, Jack Baty, Jay Rajput,
+  Jean-Charles Bagneris, Jeremy Friesen, Jonathan Sahar, Johan
+  Bolmsjö, Juanjo Presa, Kai von Fintel, Kaushal Modi, M. Hadi
+  Timachi, Mirko Hernandez, Niall Dooley, Paul van Gelder, Peter
+  Prevos, Shreyas Ragavan, Stefan Thesing, Summer Emacs, Sven Seebeck,
+  Taoufik, Viktor Haag, Wade Mealing, Yi Liu, Ypot, atanasj, doolio,
+  drcxd, hpgisler, pRot0ta1p, rbenit68, relict007, sienic, sundar bp.
+
+Special thanks to Peter Povinec who helped refine the file-naming
+scheme, which is the cornerstone of this project.
+
+Special thanks to Jean-Philippe Gagné Guay for the numerous
+contributions to the code base.
+
+* GNU Free Documentation License
+:PROPERTIES:
+:APPENDIX: t
+:CUSTOM_ID: h:2d84e73e-c143-43b5-b388-a6765da974ea
+:END:
+
+#+texinfo: @include doclicense.texi
+
+#+begin_export html
+<pre>
+
+                GNU Free Documentation License
+                 Version 1.3, 3 November 2008
+
+
+ Copyright (C) 2000, 2001, 2002, 2007, 2008 Free Software Foundation, Inc.
+     <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+0. PREAMBLE
+
+The purpose of this License is to make a manual, textbook, or other
+functional and useful document "free" in the sense of freedom: to
+assure everyone the effective freedom to copy and redistribute it,
+with or without modifying it, either commercially or noncommercially.
+Secondarily, this License preserves for the author and publisher a way
+to get credit for their work, while not being considered responsible
+for modifications made by others.
+
+This License is a kind of "copyleft", which means that derivative
+works of the document must themselves be free in the same sense.  It
+complements the GNU General Public License, which is a copyleft
+license designed for free software.
+
+We have designed this License in order to use it for manuals for free
+software, because free software needs free documentation: a free
+program should come with manuals providing the same freedoms that the
+software does.  But this License is not limited to software manuals;
+it can be used for any textual work, regardless of subject matter or
+whether it is published as a printed book.  We recommend this License
+principally for works whose purpose is instruction or reference.
+
+
+1. APPLICABILITY AND DEFINITIONS
+
+This License applies to any manual or other work, in any medium, that
+contains a notice placed by the copyright holder saying it can be
+distributed under the terms of this License.  Such a notice grants a
+world-wide, royalty-free license, unlimited in duration, to use that
+work under the conditions stated herein.  The "Document", below,
+refers to any such manual or work.  Any member of the public is a
+licensee, and is addressed as "you".  You accept the license if you
+copy, modify or distribute the work in a way requiring permission
+under copyright law.
+
+A "Modified Version" of the Document means any work containing the
+Document or a portion of it, either copied verbatim, or with
+modifications and/or translated into another language.
+
+A "Secondary Section" is a named appendix or a front-matter section of
+the Document that deals exclusively with the relationship of the
+publishers or authors of the Document to the Document's overall
+subject (or to related matters) and contains nothing that could fall
+directly within that overall subject.  (Thus, if the Document is in
+part a textbook of mathematics, a Secondary Section may not explain
+any mathematics.)  The relationship could be a matter of historical
+connection with the subject or with related matters, or of legal,
+commercial, philosophical, ethical or political position regarding
+them.
+
+The "Invariant Sections" are certain Secondary Sections whose titles
+are designated, as being those of Invariant Sections, in the notice
+that says that the Document is released under this License.  If a
+section does not fit the above definition of Secondary then it is not
+allowed to be designated as Invariant.  The Document may contain zero
+Invariant Sections.  If the Document does not identify any Invariant
+Sections then there are none.
+
+The "Cover Texts" are certain short passages of text that are listed,
+as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+the Document is released under this License.  A Front-Cover Text may
+be at most 5 words, and a Back-Cover Text may be at most 25 words.
+
+A "Transparent" copy of the Document means a machine-readable copy,
+represented in a format whose specification is available to the
+general public, that is suitable for revising the document
+straightforwardly with generic text editors or (for images composed of
+pixels) generic paint programs or (for drawings) some widely available
+drawing editor, and that is suitable for input to text formatters or
+for automatic translation to a variety of formats suitable for input
+to text formatters.  A copy made in an otherwise Transparent file
+format whose markup, or absence of markup, has been arranged to thwart
+or discourage subsequent modification by readers is not Transparent.
+An image format is not Transparent if used for any substantial amount
+of text.  A copy that is not "Transparent" is called "Opaque".
+
+Examples of suitable formats for Transparent copies include plain
+ASCII without markup, Texinfo input format, LaTeX input format, SGML
+or XML using a publicly available DTD, and standard-conforming simple
+HTML, PostScript or PDF designed for human modification.  Examples of
+transparent image formats include PNG, XCF and JPG.  Opaque formats
+include proprietary formats that can be read and edited only by
+proprietary word processors, SGML or XML for which the DTD and/or
+processing tools are not generally available, and the
+machine-generated HTML, PostScript or PDF produced by some word
+processors for output purposes only.
+
+The "Title Page" means, for a printed book, the title page itself,
+plus such following pages as are needed to hold, legibly, the material
+this License requires to appear in the title page.  For works in
+formats which do not have any title page as such, "Title Page" means
+the text near the most prominent appearance of the work's title,
+preceding the beginning of the body of the text.
+
+The "publisher" means any person or entity that distributes copies of
+the Document to the public.
+
+A section "Entitled XYZ" means a named subunit of the Document whose
+title either is precisely XYZ or contains XYZ in parentheses following
+text that translates XYZ in another language.  (Here XYZ stands for a
+specific section name mentioned below, such as "Acknowledgements",
+"Dedications", "Endorsements", or "History".)  To "Preserve the Title"
+of such a section when you modify the Document means that it remains a
+section "Entitled XYZ" according to this definition.
+
+The Document may include Warranty Disclaimers next to the notice which
+states that this License applies to the Document.  These Warranty
+Disclaimers are considered to be included by reference in this
+License, but only as regards disclaiming warranties: any other
+implication that these Warranty Disclaimers may have is void and has
+no effect on the meaning of this License.
+
+2. VERBATIM COPYING
+
+You may copy and distribute the Document in any medium, either
+commercially or noncommercially, provided that this License, the
+copyright notices, and the license notice saying this License applies
+to the Document are reproduced in all copies, and that you add no
+other conditions whatsoever to those of this License.  You may not use
+technical measures to obstruct or control the reading or further
+copying of the copies you make or distribute.  However, you may accept
+compensation in exchange for copies.  If you distribute a large enough
+number of copies you must also follow the conditions in section 3.
+
+You may also lend copies, under the same conditions stated above, and
+you may publicly display copies.
+
+
+3. COPYING IN QUANTITY
+
+If you publish printed copies (or copies in media that commonly have
+printed covers) of the Document, numbering more than 100, and the
+Document's license notice requires Cover Texts, you must enclose the
+copies in covers that carry, clearly and legibly, all these Cover
+Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on
+the back cover.  Both covers must also clearly and legibly identify
+you as the publisher of these copies.  The front cover must present
+the full title with all words of the title equally prominent and
+visible.  You may add other material on the covers in addition.
+Copying with changes limited to the covers, as long as they preserve
+the title of the Document and satisfy these conditions, can be treated
+as verbatim copying in other respects.
+
+If the required texts for either cover are too voluminous to fit
+legibly, you should put the first ones listed (as many as fit
+reasonably) on the actual cover, and continue the rest onto adjacent
+pages.
+
+If you publish or distribute Opaque copies of the Document numbering
+more than 100, you must either include a machine-readable Transparent
+copy along with each Opaque copy, or state in or with each Opaque copy
+a computer-network location from which the general network-using
+public has access to download using public-standard network protocols
+a complete Transparent copy of the Document, free of added material.
+If you use the latter option, you must take reasonably prudent steps,
+when you begin distribution of Opaque copies in quantity, to ensure
+that this Transparent copy will remain thus accessible at the stated
+location until at least one year after the last time you distribute an
+Opaque copy (directly or through your agents or retailers) of that
+edition to the public.
+
+It is requested, but not required, that you contact the authors of the
+Document well before redistributing any large number of copies, to
+give them a chance to provide you with an updated version of the
+Document.
+
+
+4. MODIFICATIONS
+
+You may copy and distribute a Modified Version of the Document under
+the conditions of sections 2 and 3 above, provided that you release
+the Modified Version under precisely this License, with the Modified
+Version filling the role of the Document, thus licensing distribution
+and modification of the Modified Version to whoever possesses a copy
+of it.  In addition, you must do these things in the Modified Version:
+
+A. Use in the Title Page (and on the covers, if any) a title distinct
+   from that of the Document, and from those of previous versions
+   (which should, if there were any, be listed in the History section
+   of the Document).  You may use the same title as a previous version
+   if the original publisher of that version gives permission.
+B. List on the Title Page, as authors, one or more persons or entities
+   responsible for authorship of the modifications in the Modified
+   Version, together with at least five of the principal authors of the
+   Document (all of its principal authors, if it has fewer than five),
+   unless they release you from this requirement.
+C. State on the Title page the name of the publisher of the
+   Modified Version, as the publisher.
+D. Preserve all the copyright notices of the Document.
+E. Add an appropriate copyright notice for your modifications
+   adjacent to the other copyright notices.
+F. Include, immediately after the copyright notices, a license notice
+   giving the public permission to use the Modified Version under the
+   terms of this License, in the form shown in the Addendum below.
+G. Preserve in that license notice the full lists of Invariant Sections
+   and required Cover Texts given in the Document's license notice.
+H. Include an unaltered copy of this License.
+I. Preserve the section Entitled "History", Preserve its Title, and add
+   to it an item stating at least the title, year, new authors, and
+   publisher of the Modified Version as given on the Title Page.  If
+   there is no section Entitled "History" in the Document, create one
+   stating the title, year, authors, and publisher of the Document as
+   given on its Title Page, then add an item describing the Modified
+   Version as stated in the previous sentence.
+J. Preserve the network location, if any, given in the Document for
+   public access to a Transparent copy of the Document, and likewise
+   the network locations given in the Document for previous versions
+   it was based on.  These may be placed in the "History" section.
+   You may omit a network location for a work that was published at
+   least four years before the Document itself, or if the original
+   publisher of the version it refers to gives permission.
+K. For any section Entitled "Acknowledgements" or "Dedications",
+   Preserve the Title of the section, and preserve in the section all
+   the substance and tone of each of the contributor acknowledgements
+   and/or dedications given therein.
+L. Preserve all the Invariant Sections of the Document,
+   unaltered in their text and in their titles.  Section numbers
+   or the equivalent are not considered part of the section titles.
+M. Delete any section Entitled "Endorsements".  Such a section
+   may not be included in the Modified Version.
+N. Do not retitle any existing section to be Entitled "Endorsements"
+   or to conflict in title with any Invariant Section.
+O. Preserve any Warranty Disclaimers.
+
+If the Modified Version includes new front-matter sections or
+appendices that qualify as Secondary Sections and contain no material
+copied from the Document, you may at your option designate some or all
+of these sections as invariant.  To do this, add their titles to the
+list of Invariant Sections in the Modified Version's license notice.
+These titles must be distinct from any other section titles.
+
+You may add a section Entitled "Endorsements", provided it contains
+nothing but endorsements of your Modified Version by various
+parties--for example, statements of peer review or that the text has
+been approved by an organization as the authoritative definition of a
+standard.
+
+You may add a passage of up to five words as a Front-Cover Text, and a
+passage of up to 25 words as a Back-Cover Text, to the end of the list
+of Cover Texts in the Modified Version.  Only one passage of
+Front-Cover Text and one of Back-Cover Text may be added by (or
+through arrangements made by) any one entity.  If the Document already
+includes a cover text for the same cover, previously added by you or
+by arrangement made by the same entity you are acting on behalf of,
+you may not add another; but you may replace the old one, on explicit
+permission from the previous publisher that added the old one.
+
+The author(s) and publisher(s) of the Document do not by this License
+give permission to use their names for publicity for or to assert or
+imply endorsement of any Modified Version.
+
+
+5. COMBINING DOCUMENTS
+
+You may combine the Document with other documents released under this
+License, under the terms defined in section 4 above for modified
+versions, provided that you include in the combination all of the
+Invariant Sections of all of the original documents, unmodified, and
+list them all as Invariant Sections of your combined work in its
+license notice, and that you preserve all their Warranty Disclaimers.
+
+The combined work need only contain one copy of this License, and
+multiple identical Invariant Sections may be replaced with a single
+copy.  If there are multiple Invariant Sections with the same name but
+different contents, make the title of each such section unique by
+adding at the end of it, in parentheses, the name of the original
+author or publisher of that section if known, or else a unique number.
+Make the same adjustment to the section titles in the list of
+Invariant Sections in the license notice of the combined work.
+
+In the combination, you must combine any sections Entitled "History"
+in the various original documents, forming one section Entitled
+"History"; likewise combine any sections Entitled "Acknowledgements",
+and any sections Entitled "Dedications".  You must delete all sections
+Entitled "Endorsements".
+
+
+6. COLLECTIONS OF DOCUMENTS
+
+You may make a collection consisting of the Document and other
+documents released under this License, and replace the individual
+copies of this License in the various documents with a single copy
+that is included in the collection, provided that you follow the rules
+of this License for verbatim copying of each of the documents in all
+other respects.
+
+You may extract a single document from such a collection, and
+distribute it individually under this License, provided you insert a
+copy of this License into the extracted document, and follow this
+License in all other respects regarding verbatim copying of that
+document.
+
+
+7. AGGREGATION WITH INDEPENDENT WORKS
+
+A compilation of the Document or its derivatives with other separate
+and independent documents or works, in or on a volume of a storage or
+distribution medium, is called an "aggregate" if the copyright
+resulting from the compilation is not used to limit the legal rights
+of the compilation's users beyond what the individual works permit.
+When the Document is included in an aggregate, this License does not
+apply to the other works in the aggregate which are not themselves
+derivative works of the Document.
+
+If the Cover Text requirement of section 3 is applicable to these
+copies of the Document, then if the Document is less than one half of
+the entire aggregate, the Document's Cover Texts may be placed on
+covers that bracket the Document within the aggregate, or the
+electronic equivalent of covers if the Document is in electronic form.
+Otherwise they must appear on printed covers that bracket the whole
+aggregate.
+
+
+8. TRANSLATION
+
+Translation is considered a kind of modification, so you may
+distribute translations of the Document under the terms of section 4.
+Replacing Invariant Sections with translations requires special
+permission from their copyright holders, but you may include
+translations of some or all Invariant Sections in addition to the
+original versions of these Invariant Sections.  You may include a
+translation of this License, and all the license notices in the
+Document, and any Warranty Disclaimers, provided that you also include
+the original English version of this License and the original versions
+of those notices and disclaimers.  In case of a disagreement between
+the translation and the original version of this License or a notice
+or disclaimer, the original version will prevail.
+
+If a section in the Document is Entitled "Acknowledgements",
+"Dedications", or "History", the requirement (section 4) to Preserve
+its Title (section 1) will typically require changing the actual
+title.
+
+
+9. TERMINATION
+
+You may not copy, modify, sublicense, or distribute the Document
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense, or distribute it is void, and
+will automatically terminate your rights under this License.
+
+However, if you cease all violation of this License, then your license
+from a particular copyright holder is reinstated (a) provisionally,
+unless and until the copyright holder explicitly and finally
+terminates your license, and (b) permanently, if the copyright holder
+fails to notify you of the violation by some reasonable means prior to
+60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, receipt of a copy of some or all of the same material does
+not give you any rights to use it.
+
+
+10. FUTURE REVISIONS OF THIS LICENSE
+
+The Free Software Foundation may publish new, revised versions of the
+GNU Free Documentation License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in
+detail to address new problems or concerns.  See
+https://www.gnu.org/licenses/.
+
+Each version of the License is given a distinguishing version number.
+If the Document specifies that a particular numbered version of this
+License "or any later version" applies to it, you have the option of
+following the terms and conditions either of that specified version or
+of any later version that has been published (not as a draft) by the
+Free Software Foundation.  If the Document does not specify a version
+number of this License, you may choose any version ever published (not
+as a draft) by the Free Software Foundation.  If the Document
+specifies that a proxy can decide which future versions of this
+License can be used, that proxy's public statement of acceptance of a
+version permanently authorizes you to choose that version for the
+Document.
+
+11. RELICENSING
+
+"Massive Multiauthor Collaboration Site" (or "MMC Site") means any
+World Wide Web server that publishes copyrightable works and also
+provides prominent facilities for anybody to edit those works.  A
+public wiki that anybody can edit is an example of such a server.  A
+"Massive Multiauthor Collaboration" (or "MMC") contained in the site
+means any set of copyrightable works thus published on the MMC site.
+
+"CC-BY-SA" means the Creative Commons Attribution-Share Alike 3.0
+license published by Creative Commons Corporation, a not-for-profit
+corporation with a principal place of business in San Francisco,
+California, as well as future copyleft versions of that license
+published by that same organization.
+
+"Incorporate" means to publish or republish a Document, in whole or in
+part, as part of another Document.
+
+An MMC is "eligible for relicensing" if it is licensed under this
+License, and if all works that were first published under this License
+somewhere other than this MMC, and subsequently incorporated in whole or
+in part into the MMC, (1) had no cover texts or invariant sections, and
+(2) were thus incorporated prior to November 1, 2008.
+
+The operator of an MMC Site may republish an MMC contained in the site
+under CC-BY-SA on the same site at any time before August 1, 2009,
+provided the MMC is eligible for relicensing.
+
+
+ADDENDUM: How to use this License for your documents
+
+To use this License in a document you have written, include a copy of
+the License in the document and put the following copyright and
+license notices just after the title page:
+
+    Copyright (c)  YEAR  YOUR NAME.
+    Permission is granted to copy, distribute and/or modify this document
+    under the terms of the GNU Free Documentation License, Version 1.3
+    or any later version published by the Free Software Foundation;
+    with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
+    A copy of the license is included in the section entitled "GNU
+    Free Documentation License".
+
+If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts,
+replace the "with...Texts." line with this:
+
+    with the Invariant Sections being LIST THEIR TITLES, with the
+    Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
+
+If you have Invariant Sections without Cover Texts, or some other
+combination of the three, merge those two alternatives to suit the
+situation.
+
+If your document contains nontrivial examples of program code, we
+recommend releasing these examples in parallel under your choice of
+free software license, such as the GNU General Public License,
+to permit their use in free software.
+</pre>
+#+end_export
+
+#+html: <!--
+
+* Indices
+:PROPERTIES:
+:CUSTOM_ID: h:dd530040-de9d-4f2b-8dfd-d8b8f14c058e
+:END:
+
+** Function index
+:PROPERTIES:
+:INDEX: fn
+:CUSTOM_ID: h:317b8c20-6dc1-4390-a20a-d01d75a48ccb
+:END:
+
+** Variable index
+:PROPERTIES:
+:INDEX: vr
+:CUSTOM_ID: h:2f69d4fe-0804-4f7f-aa57-4e03e7f20d98
+:END:
+
+** Concept index
+:PROPERTIES:
+:INDEX: cp
+:CUSTOM_ID: h:10365e44-2fc0-4b66-a613-682fea09ee68
+:END:
+
+#+html: -->

--- a/vendor/denote-2.0.0/denote-org-dblock.el
+++ b/vendor/denote-2.0.0/denote-org-dblock.el
@@ -1,0 +1,153 @@
+;;; denote-org-dblock.el --- Org Dynamic blocks for denote.el -*- lexical-binding: t -*-
+
+;; Copyright (C) 2022-2023  Free Software Foundation, Inc.
+
+;; Author: Elias Storms <elias.storms@gmail.com>
+;; Maintainer: Denote Development <~protesilaos/denote@lists.sr.ht>
+;; URL: https://git.sr.ht/~protesilaos/denote
+;; Mailing-List: https://lists.sr.ht/~protesilaos/denote
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; This file provides a specialized Org-mode extension to Denote: it
+;; introduces Org Dynamic blocks that collect links to Denote notes
+;; based on a provided regexp.  In short, this automates
+;; 'denote-add-links'.
+;;
+;; For more information, read the commented code below or refer to the
+;; Denote manual
+
+;;; Code:
+
+(require 'denote)
+(require 'org)
+
+;;; Org-mode Dynamic blocks
+
+;;;; Dynamic block to search links
+
+;; Org-mode has Dynamic blocks the content of which can be computed
+;; dynamically based on their header. This functionality can be
+;; leveraged to create automated lists of links to specific notes
+;; (similar to 'denote-add-links', but with the added benefit
+;; that the list can be updated easily).
+;;
+;; A dynamic block of the 'denote-links' type looks like this:
+;;
+;;     #+BEGIN: denote-links :regexp "denote"
+;;
+;;     #+END:
+;;
+;; With point at the #+BEGIN: line, pressing 'C-c C-c' will replace the
+;; contents of the block with links to notes matching the search
+;; ':regexp'. The regular expression can be either a regexp string or
+;; a sexp form (the latter is translated via rx).
+;; See also the denote manual on 'denote-add-links'.
+;;
+;; Inserting a block can be done via the Org-mode entry point
+;; 'org-dynamic-block-insert-dblock' and selecting 'denote-links' from
+;; the list, or directly by calling 'denote-org-dblock-insert-links'.
+;;
+;;
+;; Org Dynamic blocks of the denote-links type can have the follwoing
+;; arguments (in any order):
+;;  1. :regexp input    -- the search input (required), either as a
+;;                         regexp string or a sexp (in rx notation)
+;;  2. :missing-only t  -- to only include missing links
+;;  3. :reverse t       -- reverse sort order (or don't, when nil)
+;;  4. :block-name "n"  -- to include a name for later processing
+;;
+;; By default ':missing-only t' is included as a parameter in the
+;; block's header, so that only "missing links" are included (i.e.,
+;; links to notes that the current buffer doesn't already link to).
+;; Remove this parameter or set to 'nil' to include all matching
+;; notes.
+;;
+;; With ':reverse' the value of 'denote-link-add-links-sort' can be
+;; let-bound specifically for this list of links. For more
+;; information, see the documentation of this variable.
+;;
+;; With ':block-name "string"' include a '#+NAME: string' line in the
+;; Dynamic block. This allows use of the Dynamic block output as input
+;; for further computation, e.g. in Org source blocks.
+
+;;;###autoload
+(defun denote-org-dblock-insert-links (regexp)
+  "Create Org dynamic block to insert Denote links matching REGEXP."
+  (interactive
+    (list
+     (read-regexp "Search for notes matching REGEX: " nil 'denote-link--add-links-history)))
+  (org-create-dblock (list :name "denote-links"
+                           :regexp regexp
+                           :missing-only 't))
+  (org-update-dblock))
+
+(org-dynamic-block-define "denote-links" 'denote-org-dblock-insert-links)
+
+;; By using the `org-dblock-write:' format, Org-mode knows how to
+;; compute the dynamic block. Inner workings of this function copied
+;; from `denote-add-links'.
+(defun org-dblock-write:denote-links (params)
+  "Function to update `denote-links' Org Dynamic blocks.
+Used by `org-dblock-update' with PARAMS provided by the dynamic block."
+  (let* ((regexp (plist-get params :regexp))
+         (rx (if (listp regexp) (macroexpand `(rx ,regexp)) regexp))
+         (missing-only (plist-get params :missing-only))
+         (block-name (plist-get params :block-name))
+         (denote-link-add-links-sort (plist-get params :reverse))
+         (current-file (buffer-file-name)))
+    (when block-name
+      (insert "#+name: " block-name "\n"))
+    (if missing-only
+        (progn
+          (denote-add-missing-links rx)
+          (join-line)) ;; remove trailing empty line left by denote-link--prepare-links
+      (when-let ((files (delete current-file
+                                (denote-directory-files-matching-regexp rx))))
+        (insert (denote-link--prepare-links files current-file nil))
+        (join-line))))) ;; remove trailing empty line
+
+;;;; Dynamic block for backlinks
+
+;; Similarly, we can create a 'denote-backlinks' block that inserts
+;; links to notes that link to the current note.
+
+;; This block type takes the following parameters:
+;;  1. :reverse t       -- reverse sort order (or don't, when nil)
+
+;;;###autoload
+(defun denote-org-dblock-insert-backlinks ()
+  "Insert new Org dynamic block to include backlinks."
+  (interactive)
+  (org-create-dblock (list :name "denote-backlinks"))
+  (org-update-dblock))
+
+(org-dynamic-block-define "denote-backlinks" 'denote-org-dblock-insert-backlinks)
+
+(defun org-dblock-write:denote-backlinks (params)
+  "Function to update `denote-backlinks' Org Dynamic blocks.
+Used by `org-dblock-update' with PARAMS provided by the dynamic block."
+  (when-let* ((file (buffer-file-name))
+              (id (denote-retrieve-filename-identifier file))
+              (files (delete file (denote--retrieve-files-in-xrefs id))))
+    (let ((denote-link-add-links-sort (plist-get params :reverse)))
+      (insert (denote-link--prepare-links files file nil))
+      (join-line)))) ;; remove trailing empty line
+
+(provide 'denote-org-dblock)
+;;; denote-org-dblock.el ends here

--- a/vendor/denote-2.0.0/denote-rename-buffer.el
+++ b/vendor/denote-2.0.0/denote-rename-buffer.el
@@ -1,0 +1,100 @@
+;;; denote-rename-buffer.el --- Rename Denote buffers to be shorter and easier to read -*- lexical-binding: t -*-
+
+;; Copyright (C) 2023  Free Software Foundation, Inc.
+
+;; Author: Protesilaos Stavrou <info@protesilaos.com>
+;; Maintainer: Denote Development <~protesilaos/denote@lists.sr.ht>
+;; URL: https://git.sr.ht/~protesilaos/denote
+;; Mailing-List: https://lists.sr.ht/~protesilaos/denote
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; Rename Denote buffers to be shorter and easier to read.  Enable
+;; `denote-rename-buffer-mode' to automatically rename the buffer of a
+;; Denote file.  The renaming function is specified in the user option
+;; `denote-rename-buffer-function'.
+
+;;; Code:
+
+(require 'denote)
+
+(defgroup denote-rename-buffer nil
+  "Rename Denote buffers to be shorter and easier to read."
+  :group 'denote
+  :link '(info-link "(denote) Top")
+  :link '(url-link :tag "Homepage" "https://protesilaos.com/emacs/denote"))
+
+(defcustom denote-rename-buffer-function #'denote-rename-buffer-with-title
+  "Symbol of function that is called to rename the Denote file buffer.
+
+The function is called without arguments from the
+`find-file-hook' when `denote-rename-buffer-mode' is enabled (or
+when the user manually sets up the hook).
+
+See the function `denote-rename-buffer-with-title' (the default
+value) for a reference implementation."
+  :type '(choice
+          (const :tag "Rename using only the title" denote-rename-buffer-with-title)
+          (const :tag "Rename using only the identifier" denote-rename-buffer-with-identifier)
+          (function :tag "Use a custom renaming function"))
+  :group 'denote-rename-buffer)
+
+(defun denote-rename-buffer--common-check (buffer)
+  "Determine if BUFFER shall be renamed.
+Return the file path and the type of it as a cons cell."
+  (when-let* ((file (buffer-file-name buffer))
+              ((file-exists-p file))
+              ((denote-file-has-identifier-p file))
+              (type (denote-filetype-heuristics file)))
+    (cons file type)))
+
+(defun denote-rename-buffer-with-title (&optional buffer)
+  "Retrieve Denote file of BUFFER and rename BUFFER based on the file title.
+BUFFER is an object that satisfies `bufferp'.  If nil, then use
+the return value of `current-buffer'."
+  (when-let* ((file-and-type (denote-rename-buffer--common-check (or buffer (current-buffer))))
+              (title (denote--retrieve-title-or-filename (car file-and-type) (cdr file-and-type))))
+    (rename-buffer title :unique)))
+
+(defun denote-rename-buffer-with-identifier (&optional buffer)
+  "Retrieve Denote file of BUFFER and rename BUFFER based on the file identifier.
+BUFFER is an object that satisfies `bufferp'.  If nil, then use
+the return value of `current-buffer'."
+  (when-let* ((file-and-type (denote-rename-buffer--common-check (or buffer (current-buffer))))
+              (identifier (denote-retrieve-filename-identifier (car file-and-type))))
+    (rename-buffer identifier :unique)))
+
+(defun denote-rename-buffer-rename-function-or-fallback ()
+  "Call `denote-rename-buffer-function' or its fallback to rename with title.
+Add this to `find-file-hook'."
+  (funcall (or denote-rename-buffer-function #'denote-rename-buffer-with-title)))
+
+;;;###autoload
+(define-minor-mode denote-rename-buffer-mode
+  "Automatically rename Denote buffers to be easier to read.
+A buffer is renamed upon visiting the underlying file.  This
+means that existing buffers are not renamed until they are
+visited again in a new buffer (files are visited with the command
+`find-file' or related)."
+  :global t
+  (if denote-rename-buffer-mode
+      (add-hook 'find-file-hook #'denote-rename-buffer-rename-function-or-fallback)
+    (remove-hook 'find-file-hook #'denote-rename-buffer-rename-function-or-fallback)))
+
+(provide 'denote-rename-buffer-with-title)
+;;; denote-rename-buffer.el ends here

--- a/vendor/denote-2.0.0/denote.el
+++ b/vendor/denote-2.0.0/denote.el
@@ -1,0 +1,3947 @@
+;;; denote.el --- Simple notes with an efficient file-naming scheme -*- lexical-binding: t -*-
+
+;; Copyright (C) 2022-2023  Free Software Foundation, Inc.
+
+;; Author: Protesilaos Stavrou <info@protesilaos.com>
+;; Maintainer: Denote Development <~protesilaos/denote@lists.sr.ht>
+;; URL: https://git.sr.ht/~protesilaos/denote
+;; Mailing-List: https://lists.sr.ht/~protesilaos/denote
+;; Version: 2.0.0
+;; Package-Requires: ((emacs "28.1"))
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Denote aims to be a simple-to-use, focused-in-scope, and effective
+;; note-taking and file-naming tool for Emacs.
+;;
+;; Denote is based on the idea that files should follow a predictable
+;; and descriptive file-naming scheme.  The file name must offer a
+;; clear indication of what the contents are about, without reference
+;; to any other metadata.  Denote basically streamlines the creation
+;; of such files or file names while providing facilities to link
+;; between them (where those files are editable).
+;;
+;; Denote's file-naming scheme is not limited to "notes".  It can be used
+;; for all types of file, including those that are not editable in Emacs,
+;; such as videos.  Naming files in a constistent way makes their
+;; filtering and retrieval considerably easier.  Denote provides relevant
+;; facilities to rename files, regardless of file type.
+;;
+;; The manual describes all the technicalities about the file-naming
+;; scheme, points of entry to creating new notes, commands to check
+;; links between notes, and more: ;; <https://protesilaos.com/emacs/denote>.
+;; If you have the info manual available, evaluate:
+;;
+;;    (info "(denote) Top")
+;;
+;; What follows is a general overview of its core core design
+;; principles (again: please read the manual for the technicalities):
+;;
+;; * Predictability :: File names must follow a consistent and
+;;   descriptive naming convention (see the manual's "The file-naming
+;;   scheme").  The file name alone should offer a clear indication of
+;;   what the contents are, without reference to any other metadatum.
+;;   This convention is not specific to note-taking, as it is pertinent
+;;   to any form of file that is part of the user's long-term storage
+;;   (see the manual's "Renaming files").
+;;
+;; * Composability :: Be a good Emacs citizen, by integrating with other
+;;   packages or built-in functionality instead of re-inventing
+;;   functions such as for filtering or greping.  The author of Denote
+;;   (Protesilaos, aka "Prot") writes ordinary notes in plain text
+;;   (`.txt'), switching on demand to an Org file only when its expanded
+;;   set of functionality is required for the task at hand (see the
+;;   manual's "Points of entry").
+;;
+;; * Portability :: Notes are plain text and should remain portable.
+;;   The way Denote writes file names, the front matter it includes in
+;;   the note's header, and the links it establishes must all be
+;;   adequately usable with standard Unix tools.  No need for a databse
+;;   or some specialised software.  As Denote develops and this manual
+;;   is fully fleshed out, there will be concrete examples on how to do
+;;   the Denote-equivalent on the command-line.
+;;
+;; * Flexibility :: Do not assume the user's preference for a
+;;   note-taking methodology.  Denote is conceptually similar to the
+;;   Zettelkasten Method, which you can learn more about in this
+;;   detailed introduction: <https://zettelkasten.de/introduction/>.
+;;   Notes are atomic (one file per note) and have a unique identifier.
+;;   However, Denote does not enforce a particular methodology for
+;;   knowledge management, such as a restricted vocabulary or mutually
+;;   exclusive sets of keywords.  Denote also does not check if the user
+;;   writes thematically atomic notes.  It is up to the user to apply
+;;   the requisite rigor and/or creativity in pursuit of their preferred
+;;   workflow (see the manual's "Writing metanotes").
+;;
+;; * Hackability :: Denote's code base consists of small and reusable
+;;   functions.  They all have documentation strings.  The idea is to
+;;   make it easier for users of varying levels of expertise to
+;;   understand what is going on and make surgical interventions where
+;;   necessary (e.g. to tweak some formatting).  In this manual, we
+;;   provide concrete examples on such user-level configurations (see
+;;   the manual's "Keep a journal or diary").
+;;
+;; Now the important part...  "Denote" is the familiar word, though it
+;; also is a play on the "note" concept.  Plus, we can come up with
+;; acronyms, recursive or otherwise, of increasingly dubious utility
+;; like:
+;;
+;; + Don't Ever Note Only The Epiphenomenal
+;; + Denote Everything Neatly; Omit The Excesses
+;;
+;; But we'll let you get back to work.  Don't Eschew or Neglect your
+;; Obligations, Tasks, and Engagements.
+
+;;; Code:
+
+(require 'seq)
+(require 'xref)
+(require 'dired)
+(eval-when-compile (require 'subr-x))
+
+(defgroup denote ()
+  "Simple notes with an efficient file-naming scheme."
+  :group 'files
+  :link '(info-link "(denote) Top")
+  :link '(url-link :tag "Homepage" "https://protesilaos.com/emacs/denote"))
+
+;;;; User options
+
+;; About the autoload: (info "(elisp) File Local Variables")
+
+;;;###autoload (put 'denote-directory 'safe-local-variable (lambda (val) (or (eq val 'local) (eq val 'default-directory))))
+(defcustom denote-directory (expand-file-name "~/Documents/notes/")
+  "Directory for storing personal notes.
+
+A safe local value of either `default-directory' or `local' can
+be added as a value in a .dir-local.el file.  Do this if you
+intend to use multiple directory silos for your notes while still
+relying on a global value (which is the value of this variable).
+The Denote manual has a sample (search for '.dir-locals.el').
+Those silos do not communicate with each other: they remain
+separate.
+
+The local value influences where commands such as `denote' will
+place the newly created note.  If the command is called from a
+directory or file where the local value exists, then that value
+take precedence, otherwise the global value is used.
+
+If you intend to reference this variable in Lisp, consider using
+the function `denote-directory' instead: it returns the path as a
+directory and also checks if a safe local value should be used."
+  :group 'denote
+  :safe (lambda (val) (or (eq val 'local) (eq val 'default-directory)))
+  :package-version '(denote . "2.0.0")
+  :link '(info-link "(denote) Maintain separate directories for notes")
+  :type 'directory)
+
+(defcustom denote-known-keywords
+  '("emacs" "philosophy" "politics" "economics")
+  "List of strings with predefined keywords for `denote'.
+Also see user options: `denote-allow-multi-word-keywords',
+`denote-infer-keywords', `denote-sort-keywords'."
+  :group 'denote
+  :package-version '(denote . "0.1.0")
+  :type '(repeat string))
+
+(defcustom denote-infer-keywords t
+  "Whether to infer keywords from existing notes' file names.
+
+When non-nil, search the file names of existing notes in the
+variable `denote-directory' for their keyword field and extract
+the entries as \"inferred keywords\".  These are combined with
+`denote-known-keywords' and are presented as completion
+candidates while using `denote' and related commands
+interactively.
+
+If nil, refrain from inferring keywords.  The aforementioned
+completion prompt only shows the `denote-known-keywords'.  Use
+this if you want to enforce a restricted vocabulary.
+
+The user option `denote-excluded-keywords-regexp' can be used to
+exclude keywords that match a regular expression.
+
+Inferred keywords are specific to the value of the variable
+`denote-directory'.  If a silo with a local value is used, as
+explained in that variable's doc string, the inferred keywords
+are specific to the given silo.
+
+For advanced Lisp usage, the function `denote-keywords' returns
+the appropriate list of strings."
+  :group 'denote
+  :package-version '(denote . "0.1.0")
+  :type 'boolean)
+
+(defcustom denote-prompts '(title keywords)
+  "Specify the prompts of the `denote' command for interactive use.
+
+The value is a list of symbols, which includes any of the following:
+
+- `title': Prompt for the title of the new note.
+
+- `keywords': Prompts with completion for the keywords of the new
+  note.  Available candidates are those specified in the user
+  option `denote-known-keywords'.  If the user option
+  `denote-infer-keywords' is non-nil, keywords in existing note
+  file names are included in the list of candidates.  The
+  `keywords' prompt uses `completing-read-multiple', meaning that
+  it can accept multiple keywords separated by a comma (or
+  whatever the value of `crm-separator' is).
+
+- `file-type': Prompts with completion for the file type of the
+  new note.  Available candidates are those specified in the user
+  option `denote-file-type'.  Without this prompt, `denote' uses
+  the value of `denote-file-type'.
+
+- `subdirectory': Prompts with completion for a subdirectory in
+  which to create the note.  Available candidates are the value
+  of the user option `denote-directory' and all of its
+  subdirectories.  Any subdirectory must already exist: Denote
+  will not create it.
+
+- `date': Prompts for the date of the new note.  It will expect
+  an input like 2022-06-16 or a date plus time: 2022-06-16 14:30.
+  Without the `date' prompt, the `denote' command uses the
+  `current-time'.  (To leverage the more sophisticated Org
+  method, see the `denote-date-prompt-use-org-read-date'.)
+
+- `template': Prompts for a KEY among `denote-templates'.  The
+  value of that KEY is used to populate the new note with
+  content, which is added after the front matter.
+
+- `signature': Prompts for an arbitrary string that can be used
+  to establish a sequential relationship between files (e.g. 1,
+  1a, 1b, 1b1, 1b2, ...).  Signatures have no strictly defined
+  function and are up to the user to apply as they see fit.  One
+  use-case is to implement Niklas Luhmann's Zettelkasten system
+  for a sequence of notes (Folgezettel).  Signatures are not
+  included in a file's front matter and are not shown in the
+  description of a link.  They are reserved solely for creating a
+  sequence in a file listing, at least for the time being.
+
+The prompts occur in the given order.
+
+If the value of this user option is nil, no prompts are used.
+The resulting file name will consist of an identifier (i.e. the
+date and time) and a supported file type extension (per
+`denote-file-type').
+
+Recall that Denote's standard file-naming scheme is defined as
+follows (read the manual for the technicalities):
+
+    DATE--TITLE__KEYWORDS.EXT
+
+Depending on the inclusion of the `title', `keywords', and
+`signature' prompts, file names will be any of those
+permutations:
+
+    DATE.EXT
+    DATE--TITLE.EXT
+    DATE__KEYWORDS.EXT
+    DATE==SIGNATURE.EXT
+    DATE==SIGNATURE--TITLE.EXT
+    DATE==SIGNATURE--TITLE__KEYWORDS.EXT
+    DATE==SIGNATURE__KEYWORDS.EXT
+
+When in doubt, always include the `title' and `keywords'
+prompts (the default style).
+
+Finally, this user option only affects the interactive use of the
+`denote' command (advanced users can call it from Lisp).  For
+ad-hoc interactive actions that do not change the default
+behaviour of the `denote' command, users can invoke these
+convenience commands: `denote-type', `denote-subdirectory',
+`denote-date', `denote-template', `denote-signature'."
+  :group 'denote
+  :package-version '(denote . "2.0.0")
+  :link '(info-link "(denote) The denote-prompts option")
+  :type '(radio (const :tag "Use no prompts" nil)
+                (set :tag "Available prompts" :greedy t
+                     (const :tag "Title" title)
+                     (const :tag "Keywords" keywords)
+                     (const :tag "Date" date)
+                     (const :tag "File type extension" file-type)
+                     (const :tag "Subdirectory" subdirectory)
+                     (const :tag "Template" template)
+                     (const :tag "Signature" signature))))
+
+(defcustom denote-sort-keywords t
+  "Whether to sort keywords in new files.
+
+When non-nil, the keywords of `denote' are sorted with
+`string-lessp' regardless of the order they were inserted at the
+minibuffer prompt.
+
+If nil, show the keywords in their given order."
+  :group 'denote
+  :package-version '(denote . "0.1.0")
+  :type 'boolean)
+
+(defcustom denote-allow-multi-word-keywords nil
+  "If non-nil keywords can consist of multiple words.
+Words are automatically separated by a hyphen when using the
+`denote' command or related.  The hyphen is the only legal
+character---no spaces, no other characters.  If, for example, the
+user types <word1_word2> or <word1 word2>, it is converted to
+<word1-word2>.
+
+When nil (the default), do not allow keywords to consist of
+multiple words.  Reduce them to a single word, such as by turning
+<word1_word2> or <word1 word2> into <word1word2>.
+
+[ The author of Denote encourages you to use single words for
+  keywords and, if needed, rely on multiple separate keywords to
+  derive meaning.]"
+  :group 'denote
+  :package-version '(denote . "2.0.0")
+  :type 'boolean)
+
+(defcustom denote-file-type nil
+  "The file type extension for new notes.
+
+By default (a nil value), the file type is that of Org mode.
+Though the `org' symbol can be specified for the same effect.
+
+When the value is the symbol `markdown-yaml', the file type is
+that of Markdown mode and the front matter uses YAML notation.
+Similarly, `markdown-toml' is Markdown but has TOML syntax in the
+front matter.
+
+When the value is `text', the file type is that of Text mode.
+
+Any other non-nil value is the same as the default.
+
+NOTE: expert users can change the supported file types by leaving
+the value of this user option to nil and directly editing the
+value of `denote-file-types'.  That variable, which is not a user
+option, controls the behaviour of all file-type-aware
+functions (creating notes, renaming them, inserting front matter,
+formatting a link, etc.).  Consult its documentation for the
+technicalities."
+  :type '(choice
+          (const :tag "Unspecified (defaults to Org)" nil)
+          (const :tag "Org mode (default)" org)
+          (const :tag "Markdown (YAML front matter)" markdown-yaml)
+          (const :tag "Markdown (TOML front matter)" markdown-toml)
+          (const :tag "Plain text" text))
+  :package-version '(denote . "0.6.0")
+  :group 'denote)
+
+(defcustom denote-date-format nil
+  "Date format in the front matter (file header) of new notes.
+
+When nil (the default value), use a file-type-specific
+format (also check `denote-file-type'):
+
+- For Org, an inactive timestamp is used, such as [2022-06-30 Wed
+  15:31].
+
+- For Markdown, the RFC3339 standard is applied:
+  2022-06-30T15:48:00+03:00.
+
+- For plain text, the format is that of ISO 8601: 2022-06-30.
+
+If the value is a string, ignore the above and use it instead.
+The string must include format specifiers for the date.  These
+are described in the doc string of `format-time-string'."
+  :type '(choice
+          (const :tag "Use appropiate format for each file type" nil)
+          (string :tag "Custom format for `format-time-string'"))
+  :package-version '(denote . "0.2.0")
+  :group 'denote)
+
+(defcustom denote-date-prompt-use-org-read-date nil
+  "Whether to use `org-read-date' in date prompts.
+
+If non-nil, use `org-read-date'.  If nil, input the date as a
+string, as described in `denote'.
+
+This option is relevant when `denote-prompts' includes a `date'
+and/or when the user invokes the command `denote-date'."
+  :group 'denote
+  :package-version '(denote . "0.6.0")
+  :type 'boolean)
+
+(defcustom denote-templates nil
+  "Alist of content templates for new notes.
+A template is arbitrary text that Denote will add to a newly
+created note right below the front matter.
+
+Templates are expressed as a (KEY . STRING) association.
+
+- The KEY is the name which identifies the template.  It is an
+  arbitrary symbol, such as `report', `memo', `statement'.
+
+- The STRING is ordinary text that Denote will insert as-is.  It
+  can contain newline characters to add spacing.  The manual of
+  Denote contains examples on how to use the `concat' function,
+  beside writing a generic string.
+
+The user can choose a template either by invoking the command
+`denote-template' or by changing the user option `denote-prompts'
+to always prompt for a template when calling the `denote'
+command."
+  :type '(alist :key-type symbol :value-type string)
+  :package-version '(denote . "0.5.0")
+  :link '(info-link "(denote) The denote-templates option")
+  :group 'denote)
+
+(defcustom denote-backlinks-show-context nil
+  "When non-nil, show link context in the backlinks buffer.
+
+The context is the line a link to the current note is found in.
+The context includes multiple links to the same note, if those
+are present.
+
+When nil, only show a simple list of file names that link to the
+current note."
+  :group 'denote
+  :package-version '(denote . "1.2.0")
+  :type 'boolean)
+
+(make-obsolete-variable 'denote-link-fontify-backlinks 'denote-backlinks-show-context "1.2.0")
+
+(defcustom denote-excluded-directories-regexp nil
+  "Regular expression of directories to exclude from all operations.
+Omit matching directories from file prompts and also exclude them
+from all functions that check the contents of the variable
+`denote-directory'.  The regexp needs to match only the name of
+the directory, not its full path.
+
+File prompts are used by several commands, such as `denote-link'
+and `denote-subdirectory'.
+
+Functions that check for files include `denote-directory-files'
+and `denote-directory-subdirectories'.
+
+The match is performed with `string-match-p'."
+  :group 'denote
+  :package-version '(denote . "1.2.0")
+  :type 'string)
+
+(defcustom denote-excluded-keywords-regexp nil
+  "Regular expression of keywords to not infer.
+Keywords are inferred from file names and provided at relevant
+prompts as completion candidates when the user option
+`denote-infer-keywords' is non-nil.
+
+The match is performed with `string-match-p'."
+  :group 'denote
+  :package-version '(denote . "1.2.0")
+  :type 'string)
+
+;;;; Main variables
+
+;; For character classes, evaluate: (info "(elisp) Char Classes")
+(define-obsolete-variable-alias
+  'denote--id-format
+  'denote-id-format
+  "1.0.0")
+
+(defconst denote-id-format "%Y%m%dT%H%M%S"
+  "Format of ID prefix of a note's filename.
+The note's ID is derived from the date and time of its creation.")
+
+(define-obsolete-variable-alias
+  'denote--id-regexp
+  'denote-id-regexp
+  "1.0.0")
+
+(defconst denote-id-regexp "\\([0-9]\\{8\\}\\)\\(T[0-9]\\{6\\}\\)"
+  "Regular expression to match `denote-id-format'.")
+
+(defconst denote-signature-regexp "==\\([[:alnum:][:nonascii:]=]*\\)"
+  "Regular expression to match the SIGNATURE field in a file name.")
+
+(define-obsolete-variable-alias
+  'denote--title-regexp
+  'denote-title-regexp
+  "1.0.0")
+
+(defconst denote-title-regexp "--\\([[:alnum:][:nonascii:]-]*\\)"
+  "Regular expression to match the TITLE field in a file name.")
+
+(define-obsolete-variable-alias
+  'denote--keywords-regexp
+  'denote-keywords-regexp
+  "1.0.0")
+
+(defconst denote-keywords-regexp "__\\([[:alnum:][:nonascii:]_-]*\\)"
+  "Regular expression to match the KEYWORDS field in a file name.")
+
+(define-obsolete-variable-alias
+  'denote--punctuation-regexp
+  'denote-excluded-punctuation-regexp
+  "1.0.0")
+
+(defconst denote-excluded-punctuation-regexp "[][{}!@#$%^&*()=+'\"?,.\|;:~`‘’“”/]*"
+  "Punctionation that is removed from file names.
+We consider those characters illegal for our purposes.")
+
+(define-obsolete-variable-alias
+  'denote-punctuation-excluded-extra-regexp
+  'denote-excluded-punctuation-extra-regexp
+  "1.0.0")
+
+(defvar denote-excluded-punctuation-extra-regexp nil
+  "Additional punctuation that is removed from file names.
+This variable is for advanced users who need to extend the
+`denote-excluded-punctuation-regexp'.  Once we have a better
+understanding of what we should be omitting, we will update
+things accordingly.")
+
+;;;; File helper functions
+
+(defun denote--completion-table (category candidates)
+  "Pass appropriate metadata CATEGORY to completion CANDIDATES."
+  (lambda (string pred action)
+    (if (eq action 'metadata)
+        `(metadata (category . ,category))
+      (complete-with-action action candidates string pred))))
+
+(defun denote--default-directory-is-silo-p ()
+  "Return path to silo if `default-directory' is a silo."
+  (when-let ((dir-locals (dir-locals-find-file default-directory))
+             ((alist-get 'denote-directory dir-local-variables-alist)))
+    (cond
+     ((listp dir-locals)
+      (car dir-locals))
+     ((stringp dir-locals)
+      dir-locals)
+     (t nil))))
+
+(defun denote--make-denote-directory ()
+  "Make the variable `denote-directory' and its parents, if needed."
+  (when (and (stringp denote-directory)
+             (not (file-directory-p denote-directory)))
+    (make-directory denote-directory :parents)))
+
+(defvar denote-user-enforced-denote-directory nil
+  "Value of the variable `denote-directory'.
+Use this to `let' bind a directory path, thus overriding what the
+function `denote-directory' ordinarily returns.")
+
+(defun denote-directory ()
+  "Return path of variable `denote-directory' as a proper directory.
+Custom Lisp code can `let' bind the value of the variable
+`denote-user-enforced-denote-directory' to override what this
+function returns.
+
+Otherwise, the order of precedence is to first check for a silo
+before falling back to the value of the variable
+`denote-directory'."
+  (let ((path (or denote-user-enforced-denote-directory
+                  (denote--default-directory-is-silo-p)
+                  (denote--make-denote-directory)
+                  (default-value 'denote-directory))))
+    (file-name-as-directory (expand-file-name path))))
+
+(defun denote--slug-no-punct (str)
+  "Remove punctuation from STR.
+Concretely, replace with spaces anything that matches the
+`denote-excluded-punctuation-regexp' and
+`denote-excluded-punctuation-extra-regexp'."
+  (replace-regexp-in-string
+   (concat denote-excluded-punctuation-regexp
+           denote-excluded-punctuation-extra-regexp)
+   "" str))
+
+(defun denote--slug-hyphenate (str)
+  "Replace spaces and underscores with hyphens in STR.
+Also replace multiple hyphens with a single one and remove any
+leading and trailing hyphen."
+  (replace-regexp-in-string
+   "^-\\|-$" ""
+   (replace-regexp-in-string
+    "-\\{2,\\}" "-"
+    (replace-regexp-in-string "_\\|\s+" "-" str))))
+
+(defun denote-sluggify (str)
+  "Make STR an appropriate slug for file names and related."
+  (downcase (denote--slug-hyphenate (denote--slug-no-punct str))))
+
+(define-obsolete-function-alias
+  'denote--sluggify
+  'denote-sluggify
+  "1.0.0")
+
+(defun denote--slug-put-equals (str)
+  "Replace spaces and underscores with equals signs in STR.
+Also replace multiple equals signs with a single one and remove
+any leading and trailing signs."
+  (replace-regexp-in-string
+   "^=\\|=$" ""
+   (replace-regexp-in-string
+    "=\\{2,\\}" "="
+    (replace-regexp-in-string "_\\|\s+" "=" str))))
+
+(defun denote-sluggify-signature (str)
+  "Make STR an appropriate slug for signatures."
+  (downcase (denote--slug-put-equals (denote--slug-no-punct str))))
+
+(defun denote-sluggify-and-join (str)
+  "Sluggify STR while joining separate words."
+  (downcase
+   (replace-regexp-in-string
+    "-" ""
+    (denote--slug-hyphenate (denote--slug-no-punct str)))))
+
+(define-obsolete-function-alias
+  'denote--sluggify-and-join
+  'denote-sluggify-and-join
+  "1.0.0")
+
+(defun denote-sluggify-keywords (keywords)
+  "Sluggify KEYWORDS, which is a list of strings."
+  (if (listp keywords)
+    (mapcar
+     (if denote-allow-multi-word-keywords
+         #'denote-sluggify
+       #'denote-sluggify-and-join)
+     keywords)
+    (error "`%s' is not a list" keywords)))
+
+(define-obsolete-function-alias
+  'denote--sluggify-keywords
+  'denote-sluggify-keywords
+  "1.0.0")
+
+;; TODO 2023-05-22: Review name of `denote-desluggify' to signify what
+;; the doc string warns about.
+(defun denote-desluggify (str)
+  "Upcase first char in STR and dehyphenate STR, inverting `denote-sluggify'.
+The intent of this function is to be used on individual strings,
+such as the TITLE component of a Denote file name, but not on the
+entire file name.  Put differently, it does not work with
+signatures and keywords."
+  (let ((str (replace-regexp-in-string "-" " " str)))
+    (aset str 0 (upcase (aref str 0)))
+    str))
+
+(define-obsolete-function-alias
+  'denote--desluggify
+  'denote-desluggify
+  "1.0.0")
+
+(defun denote--file-empty-p (file)
+  "Return non-nil if FILE is empty."
+  (zerop (or (file-attribute-size (file-attributes file)) 0)))
+
+(defun denote-file-is-note-p (file)
+  "Return non-nil if FILE is an actual Denote note.
+For our purposes, a note must not be a directory, must satisfy
+`file-regular-p', its path must be part of the variable
+`denote-directory', it must have a Denote identifier in its name,
+and use one of the extensions implied by `denote-file-type'."
+  (let ((file-name (file-name-nondirectory file)))
+    (and (not (file-directory-p file))
+         (file-regular-p file)
+         (string-prefix-p (denote-directory) (expand-file-name file))
+         (string-match-p (concat "\\`" denote-id-regexp) file-name)
+         (denote-file-has-supported-extension-p file))))
+
+(define-obsolete-function-alias
+  'denote--only-note-p
+  'denote-file-is-note-p
+  "1.0.0")
+
+(defun denote-file-has-identifier-p (file)
+  "Return non-nil if FILE has a Denote identifier."
+  (when file
+    (string-match-p (concat "\\`" denote-id-regexp)
+                    (file-name-nondirectory file))))
+
+(define-obsolete-function-alias
+  'denote--file-has-identifier-p
+  'denote-file-has-identifier-p
+  "1.0.0")
+
+(defun denote-file-has-signature-p (file)
+  "Return non-nil if FILE has a Denote identifier."
+  (when file
+    (string-match-p denote-signature-regexp
+                    (file-name-nondirectory file))))
+
+(make-obsolete 'denote-file-directory-p nil "2.0.0")
+
+(defun denote-file-has-supported-extension-p (file)
+  "Return non-nil if FILE has supported extension.
+Also account for the possibility of an added .gpg suffix.
+Supported extensions are those implied by `denote-file-type'."
+  (seq-some (lambda (e)
+              (string-suffix-p e file))
+            (denote-file-type-extensions-with-encryption)))
+
+(define-obsolete-function-alias
+  'denote--file-supported-extension-p
+  'denote-file-has-supported-extension-p
+  "1.0.0")
+
+(defun denote--file-regular-writable-p (file)
+  "Return non-nil if FILE is regular and writable."
+  (and (file-regular-p file)
+       (file-writable-p file)))
+
+(defun denote-file-is-writable-and-supported-p (file)
+  "Return non-nil if FILE is writable and has supported extension."
+  (and (denote--file-regular-writable-p file)
+       (denote-file-has-supported-extension-p file)))
+
+(define-obsolete-function-alias
+  'denote--writable-and-supported-p
+  'denote-file-is-writable-and-supported-p
+  "1.0.0")
+
+(defun denote-get-file-name-relative-to-denote-directory (file)
+  "Return name of FILE relative to the variable `denote-directory'.
+FILE must be an absolute path."
+  (when-let* ((dir (denote-directory))
+              ((file-name-absolute-p file))
+              (file-name (expand-file-name file))
+              ((string-prefix-p dir file-name)))
+    (substring-no-properties file-name (length dir))))
+
+(define-obsolete-function-alias
+  'denote--file-name-relative-to-denote-directory
+  'denote-get-file-name-relative-to-denote-directory
+  "1.0.0")
+
+(defun denote-extract-id-from-string (string)
+  "Return existing Denote identifier in STRING, else nil."
+  (when (string-match denote-id-regexp string)
+    (match-string 0 string)))
+
+(define-obsolete-function-alias
+  'denote-link--id-from-string
+  'denote-extract-id-from-string
+  "1.0.0")
+
+;; TODO 2022-09-26: Maybe we can consolidate this with
+;; `denote--dir-in-denote-directory-p'?  Another check for the
+;; directory prefix is done in `denote-file-is-note-p'.
+(defun denote--default-dir-has-denote-prefix ()
+  "Test `default-directory' for variable `denote-directory' prefix."
+  (string-prefix-p (denote-directory)
+                   (expand-file-name default-directory)))
+
+(defun denote--exclude-directory-regexp-p (file)
+  "Return non-nil if FILE matches `denote-excluded-directories-regexp'."
+  (and denote-excluded-directories-regexp
+       (string-match-p denote-excluded-directories-regexp file)))
+
+(defun denote--directory-all-files-recursively ()
+  "Return list of all files in variable `denote-directory'.
+Avoids traversing dotfiles (unconditionally) and whatever matches
+`denote-excluded-directories-regexp'."
+  (directory-files-recursively
+   (denote-directory)
+   directory-files-no-dot-files-regexp
+   :include-directories
+   (lambda (f)
+     (cond
+      ((string-match-p "\\`\\." f) nil)
+      ((string-match-p "/\\." f) nil)
+      ((denote--exclude-directory-regexp-p f) nil)
+      ((file-readable-p f))
+      (t)))
+   :follow-symlinks))
+
+(defun denote-directory-files ()
+  "Return list of absolute file paths in variable `denote-directory'.
+
+Files only need to have an identifier.  The return value may thus
+include file types that are not implied by `denote-file-type'.
+To limit the return value to text files, use the function
+`denote-directory-text-only-files'.
+
+Remember that the variable `denote-directory' accepts a dir-local
+value, as explained in its doc string."
+  (mapcar
+   #'expand-file-name
+   (seq-remove
+    (lambda (f)
+      (not (denote-file-has-identifier-p f)))
+    (denote--directory-all-files-recursively))))
+
+(defun denote-directory-text-only-files ()
+  "Return list of text files in variable `denote-directory'.
+Filter `denote-directory-files' using `denote-file-is-note-p'."
+  (seq-filter #'denote-file-is-note-p (denote-directory-files)))
+
+(define-obsolete-function-alias
+  'denote--directory-files
+  'denote-directory-files
+  "1.0.0")
+
+(defun denote-directory-subdirectories ()
+  "Return list of subdirectories in variable `denote-directory'.
+Omit dotfiles (such as .git) unconditionally.  Also exclude
+whatever matches `denote-excluded-directories-regexp'."
+  (seq-remove
+   (lambda (filename)
+     (let ((rel (denote-get-file-name-relative-to-denote-directory filename)))
+       (or (not (file-directory-p filename))
+           (string-match-p "\\`\\." rel)
+           (string-match-p "/\\." rel)
+           (denote--exclude-directory-regexp-p rel))))
+   (denote--directory-all-files-recursively)))
+
+(define-obsolete-function-alias
+  'denote--subdirs
+  'denote-directory-subdirectories
+  "1.0.0")
+
+(defun denote-get-path-by-id (id)
+  "Return absolute path of ID string in `denote-directory-files'."
+  (let ((files
+         (seq-filter
+          (lambda (file)
+            (and (denote-file-has-identifier-p file)
+                 (string-prefix-p id (file-name-nondirectory file))))
+          (denote-directory-files))))
+    (if (length< files 2)
+        (car files)
+      (seq-find
+       (lambda (file)
+         (let ((file-extension (file-name-extension file :period)))
+           (and (denote-file-is-note-p file)
+                (or (string= (denote--file-extension denote-file-type)
+                             file-extension)
+                    (string= ".org" file-extension)
+                    (member file-extension (denote-file-type-extensions))))))
+       files))))
+
+(define-obsolete-function-alias
+  'denote--get-note-path-by-id
+  'denote-get-path-by-id
+  "1.0.0")
+
+(defun denote-get-relative-path-by-id (id &optional directory)
+  "Return relative path of ID string in `denote-directory-files'.
+The path is relative to DIRECTORY (default: ‘default-directory’)."
+  (file-relative-name (denote-get-path-by-id id) directory))
+
+(defun denote-directory-files-matching-regexp (regexp)
+  "Return list of files matching REGEXP in `denote-directory-files'."
+  (seq-filter
+   (lambda (f)
+     (string-match-p regexp (denote-get-file-name-relative-to-denote-directory f)))
+   (denote-directory-files)))
+
+(define-obsolete-function-alias
+  'denote--directory-files-matching-regexp
+  'denote-directory-files-matching-regexp
+  "1.0.0")
+
+(defun denote-all-files ()
+  "Return the list of Denote files in variable `denote-directory'."
+  (let* ((project-find-functions #'denote-project-find)
+         (project (project-current nil (denote-directory)))
+         (dirs (list (project-root project))))
+    (project-files project dirs)))
+
+(defvar denote--file-history nil
+  "Minibuffer history of `denote-file-prompt'.")
+
+(defun denote-file-prompt (&optional initial-text)
+  "Prompt for file with identifier in variable `denote-directory'.
+With optional INITIAL-TEXT, use it to prepopulate the minibuffer."
+  (let* ((all-files (denote-all-files))
+         (completion-ignore-case read-file-name-completion-ignore-case))
+    (when all-files
+      (funcall project-read-file-name-function
+               "Select note: " all-files nil 'denote--file-history initial-text))))
+
+(define-obsolete-function-alias
+  'denote--retrieve-read-file-prompt
+  'denote-file-prompt
+  "1.0.0")
+
+;;;; Keywords
+
+(defun denote-extract-keywords-from-path (path)
+  "Extract keywords from PATH and return them as a list of strings.
+PATH must be a Denote-style file name where keywords are prefixed
+with an underscore.
+
+If PATH has no such keywords, return nil."
+  (let* ((file-name (file-name-nondirectory path))
+         (kws (when (string-match denote-keywords-regexp file-name)
+                (match-string-no-properties 1 file-name))))
+    (when kws
+      (split-string kws "_"))))
+
+(define-obsolete-function-alias
+  'denote--extract-keywords-from-path
+  'denote-extract-keywords-from-path
+  "1.0.0")
+
+(defun denote--inferred-keywords ()
+  "Extract keywords from `denote-directory-files'.
+This function returns duplicates.  The `denote-keywords' is the
+one that doesn't."
+  (let ((kw (mapcan #'denote-extract-keywords-from-path (denote-directory-files))))
+    (if-let ((regexp denote-excluded-keywords-regexp))
+        (seq-filter (lambda (k) (not (string-match-p regexp k))) kw)
+      kw)))
+
+(defun denote-keywords ()
+  "Return appropriate list of keyword candidates.
+If `denote-infer-keywords' is non-nil, infer keywords from
+existing notes and combine them into a list with
+`denote-known-keywords'.  Else use only the latter.
+
+Inferred keywords are filtered by the user option
+`denote-excluded-keywords-regexp'."
+  (delete-dups
+   (if denote-infer-keywords
+       (append (denote--inferred-keywords) denote-known-keywords)
+     denote-known-keywords)))
+
+(defvar denote--keyword-history nil
+  "Minibuffer history of inputted keywords.")
+
+(defun denote--keywords-crm (keywords &optional prompt)
+  "Use `completing-read-multiple' for KEYWORDS.
+With optional PROMPT, use it instead of a generic text for file
+keywords."
+  (delete-dups
+   (completing-read-multiple
+    (or prompt "File keyword: ") keywords
+    nil nil nil 'denote--keyword-history)))
+
+(defun denote-keywords-prompt ()
+  "Prompt for one or more keywords.
+In the case of multiple entries, those are separated by the
+`crm-sepator', which typically is a comma.  In such a case, the
+output is sorted with `string-lessp'.
+
+Process the return value with `denote-keywords-sort'."
+  (denote-keywords-sort (denote--keywords-crm (denote-keywords))))
+
+(defun denote-keywords-sort (keywords)
+  "Sort KEYWORDS if `denote-sort-keywords' is non-nil.
+KEYWORDS is a list of strings, per `denote-keywords-prompt'."
+  (if denote-sort-keywords
+      (sort keywords #'string-lessp)
+    keywords))
+
+(define-obsolete-function-alias
+  'denote--keywords-prompt
+  'denote-keywords-prompt
+  "1.0.0")
+
+(defun denote--keywords-combine (keywords)
+  "Format KEYWORDS output of `denote-keywords-prompt'."
+  (mapconcat #'downcase keywords "_"))
+
+(defun denote--keywords-add-to-history (keywords)
+  "Append KEYWORDS to `denote--keyword-history'."
+  (mapc (lambda (kw)
+          (add-to-history 'denote--keyword-history kw))
+        (delete-dups keywords)))
+
+;;;; File types
+
+(defvar denote-org-front-matter
+  "#+title:      %s
+#+date:       %s
+#+filetags:   %s
+#+identifier: %s
+\n"
+  "Org front matter.
+It is passed to `format' with arguments TITLE, DATE, KEYWORDS,
+ID.  Advanced users are advised to consult Info node `(denote)
+Change the front matter format'.")
+
+(defvar denote-yaml-front-matter
+  "---
+title:      %s
+date:       %s
+tags:       %s
+identifier: %S
+---\n\n"
+  "YAML (Markdown) front matter.
+It is passed to `format' with arguments TITLE, DATE, KEYWORDS,
+ID.  Advanced users are advised to consult Info node `(denote)
+Change the front matter format'.")
+
+(defvar denote-toml-front-matter
+  "+++
+title      = %s
+date       = %s
+tags       = %s
+identifier = %S
++++\n\n"
+  "TOML (Markdown) front matter.
+It is passed to `format' with arguments TITLE, DATE, KEYWORDS,
+ID.  Advanced users are advised to consult Info node `(denote)
+Change the front matter format'.")
+
+(defvar denote-text-front-matter
+  "title:      %s
+date:       %s
+tags:       %s
+identifier: %s
+---------------------------\n\n"
+  "Plain text front matter.
+It is passed to `format' with arguments TITLE, DATE, KEYWORDS,
+ID.  Advanced users are advised to consult Info node `(denote)
+Change the front matter format'.")
+
+(defun denote-surround-with-quotes (s)
+  "Surround string S with quotes.
+This can be used in `denote-file-types' to format front mattter."
+  (format "%S" s))
+
+(defun denote-trim-whitespace (s)
+  "Trim whitespace around string S.
+This can be used in `denote-file-types' to format front mattter."
+  (if (string-blank-p s)
+      ""
+    (let ((trims "[ \t\n\r]+"))
+      (string-trim s trims trims))))
+
+(defun denote--trim-quotes (s)
+  "Trim quotes around string S."
+  (let ((trims "[\"']+"))
+    (string-trim s trims trims)))
+
+(defun denote-trim-whitespace-then-quotes (s)
+  "Trim whitespace then quotes around string S.
+This can be used in `denote-file-types' to format front mattter."
+  (if (string-blank-p s)
+      ""
+    (denote--trim-quotes (denote-trim-whitespace s))))
+
+(defun denote-format-keywords-for-md-front-matter (keywords)
+  "Format front matter KEYWORDS for markdown file type.
+KEYWORDS is a list of strings.  Consult the `denote-file-types'
+for how this is used."
+  (format "[%s]" (mapconcat (lambda (k) (format "%S" k)) keywords ", ")))
+
+(defun denote-format-keywords-for-text-front-matter (keywords)
+  "Format front matter KEYWORDS for text file type.
+KEYWORDS is a list of strings.  Consult the `denote-file-types'
+for how this is used."
+  (string-join keywords "  "))
+
+(defun denote-format-keywords-for-org-front-matter (keywords)
+  "Format front matter KEYWORDS for org file type.
+KEYWORDS is a list of strings.  Consult the `denote-file-types'
+for how this is used."
+  (if keywords
+      (format ":%s:" (string-join keywords ":"))
+    ""))
+
+(defun denote-extract-keywords-from-front-matter (keywords-string)
+  "Extract keywords list from front matter KEYWORDS-STRING.
+Split KEYWORDS-STRING into a list of strings.  If KEYWORDS-STRING
+satisfies `string-blank-p', return an empty string.
+
+Consult the `denote-file-types' for how this is used."
+  (if (string-blank-p keywords-string)
+      ""
+    (split-string keywords-string "[:,\s]+" t "[][ \"']+")))
+
+(defvar denote-file-types
+  '((org
+     :extension ".org"
+     :date-function denote-date-org-timestamp
+     :front-matter denote-org-front-matter
+     :title-key-regexp "^#\\+title\\s-*:"
+     :title-value-function identity
+     :title-value-reverse-function denote-trim-whitespace
+     :keywords-key-regexp "^#\\+filetags\\s-*:"
+     :keywords-value-function denote-format-keywords-for-org-front-matter
+     :keywords-value-reverse-function denote-extract-keywords-from-front-matter
+     :link denote-org-link-format
+     :link-in-context-regexp denote-org-link-in-context-regexp)
+    (markdown-yaml
+     :extension ".md"
+     :date-function denote-date-rfc3339
+     :front-matter denote-yaml-front-matter
+     :title-key-regexp "^title\\s-*:"
+     :title-value-function denote-surround-with-quotes
+     :title-value-reverse-function denote-trim-whitespace-then-quotes
+     :keywords-key-regexp "^tags\\s-*:"
+     :keywords-value-function denote-format-keywords-for-md-front-matter
+     :keywords-value-reverse-function denote-extract-keywords-from-front-matter
+     :link denote-md-link-format
+     :link-in-context-regexp denote-md-link-in-context-regexp)
+    (markdown-toml
+     :extension ".md"
+     :date-function denote-date-rfc3339
+     :front-matter denote-toml-front-matter
+     :title-key-regexp "^title\\s-*="
+     :title-value-function denote-surround-with-quotes
+     :title-value-reverse-function denote-trim-whitespace-then-quotes
+     :keywords-key-regexp "^tags\\s-*="
+     :keywords-value-function denote-format-keywords-for-md-front-matter
+     :keywords-value-reverse-function denote-extract-keywords-from-front-matter
+     :link denote-md-link-format
+     :link-in-context-regexp denote-md-link-in-context-regexp)
+    (text
+     :extension ".txt"
+     :date-function denote-date-iso-8601
+     :front-matter denote-text-front-matter
+     :title-key-regexp "^title\\s-*:"
+     :title-value-function identity
+     :title-value-reverse-function denote-trim-whitespace
+     :keywords-key-regexp "^tags\\s-*:"
+     :keywords-value-function denote-format-keywords-for-text-front-matter
+     :keywords-value-reverse-function denote-extract-keywords-from-front-matter
+     :link denote-org-link-format
+     :link-in-context-regexp denote-org-link-in-context-regexp))
+  "Alist of `denote-file-type' and their format properties.
+
+Each element is of the form (SYMBOL PROPERTY-LIST).  SYMBOL is
+one of those specified in `denote-file-type' or an arbitrary
+symbol that defines a new file type.
+
+PROPERTY-LIST is a plist that consists of the following elements:
+
+- `:extension' is a string with the file extension including the
+  period.
+
+- `:date-function' is a function that can format a date.  See the
+  functions `denote-date-iso-8601', `denote-date-rfc3339', and
+  `denote-date-org-timestamp'.
+
+- `:front-matter' is either a string passed to `format' or a
+  variable holding such a string.  The `format' function accepts
+  four arguments, which come from `denote' in this order: TITLE,
+  DATE, KEYWORDS, IDENTIFIER.  Read the doc string of `format' on
+  how to reorder arguments.
+
+- `:title-key-regexp' is a regular expression that is used to
+  retrieve the title line in a file.  The first line matching
+  this regexp is considered the title line.
+
+- `:title-value-function' is the function used to format the raw
+  title string for inclusion in the front matter (e.g. to
+  surround it with quotes).  Use the `identity' function if no
+  further processing is required.
+
+- `:title-value-reverse-function' is the function used to
+  retrieve the raw title string from the front matter.  It
+  performs the reverse of `:title-value-function'.
+
+- `:keywords-key-regexp' is a regular expression used to retrieve
+  the keywords' line in the file.  The first line matching this
+  regexp is considered the keywords' line.
+
+- `:keywords-value-function' is the function used to format the
+  keywords' list of strings as a single string, with appropriate
+  delimiters, for inclusion in the front matter.
+
+- `:keywords-value-reverse-function' is the function used to
+  retrieve the keywords' value from the front matter.  It
+  performs the reverse of the `:keywords-value-function'.
+
+- `:link' is a string, or variable holding a string, that
+  specifies the format of a link.  See the variables
+  `denote-org-link-format', `denote-md-link-format'.
+
+- `:link-in-context-regexp' is a regular expression that is used
+  to match the aforementioned link format.  See the variables
+  `denote-org-link-in-context-regexp',`denote-md-link-in-context-regexp'.
+
+If `denote-file-type' is nil, use the first element of this list
+for new note creation.  The default is `org'.")
+
+(defun denote--date-format-function (file-type)
+  "Return date format function of FILE-TYPE."
+  (plist-get
+   (alist-get file-type denote-file-types)
+   :date-function))
+
+(defun denote--file-extension (file-type)
+  "Return file type extension based on FILE-TYPE."
+  (plist-get
+   (alist-get file-type denote-file-types)
+   :extension))
+
+(defun denote--front-matter (file-type)
+  "Return front matter based on FILE-TYPE."
+  (let ((prop (plist-get
+               (alist-get file-type denote-file-types)
+               :front-matter)))
+    (if (symbolp prop)
+        (symbol-value prop)
+      prop)))
+
+(defun denote--title-key-regexp (file-type)
+  "Return the title key regexp associated to FILE-TYPE."
+  (plist-get
+   (alist-get file-type denote-file-types)
+   :title-key-regexp))
+
+(defun denote--title-value-function (file-type)
+  "Convert title string to a front matter title, per FILE-TYPE."
+  (plist-get
+   (alist-get file-type denote-file-types)
+   :title-value-function))
+
+(defun denote--title-value-reverse-function (file-type)
+  "Convert front matter title to the title string, per FILE-TYPE."
+  (plist-get
+   (alist-get file-type denote-file-types)
+   :title-value-reverse-function))
+
+(defun denote--keywords-key-regexp (file-type)
+  "Return the keywords key regexp associated to FILE-TYPE."
+  (plist-get
+   (alist-get file-type denote-file-types)
+   :keywords-key-regexp))
+
+(defun denote--keywords-value-function (file-type)
+  "Convert keywords' string to front matter keywords, per FILE-TYPE."
+  (plist-get
+   (alist-get file-type denote-file-types)
+   :keywords-value-function))
+
+(defun denote--keywords-value-reverse-function (file-type)
+  "Convert front matter keywords to keywords' list, per FILE-TYPE."
+  (plist-get
+   (alist-get file-type denote-file-types)
+   :keywords-value-reverse-function))
+
+(defun denote--link-format (file-type)
+  "Return link format extension based on FILE-TYPE."
+  (plist-get
+   (alist-get file-type denote-file-types)
+   :link))
+
+(defun denote--link-in-context-regexp (file-type)
+  "Return link regexp in context based on FILE-TYPE."
+  (plist-get
+   (alist-get file-type denote-file-types)
+   :link-in-context-regexp))
+
+(define-obsolete-function-alias
+  'denote--extensions
+  'denote-file-type-extensions
+  "2.0.0")
+
+(defun denote-file-type-extensions ()
+  "Return all file type extensions in `denote-file-types'."
+  (delete-dups
+   (mapcar (lambda (type)
+             (plist-get (cdr type) :extension))
+           denote-file-types)))
+
+(define-obsolete-variable-alias
+  'denote--encryption-file-extensions
+  'denote-encryption-file-extensions
+  "2.0.0")
+
+;; TODO 2023-01-24: Perhaps there is a good reason to make this a user
+;; option, but I am keeping it as a generic variable for now.
+(defvar denote-encryption-file-extensions '(".gpg" ".age")
+  "List of strings specifying file extensions for encryption.")
+
+(define-obsolete-function-alias
+  'denote--extensions-with-encryption
+  'denote-file-type-extensions-with-encryption
+  "2.0.0")
+
+(defun denote-file-type-extensions-with-encryption ()
+  "Derive `denote-file-type-extensions' plus `denote-encryption-file-extensions'."
+  (let ((file-extensions (denote-file-type-extensions))
+        all)
+    (dolist (ext file-extensions)
+      (dolist (enc denote-encryption-file-extensions)
+        (push (concat ext enc) all)))
+    (append file-extensions all)))
+
+(defun denote--file-type-keys ()
+  "Return all `denote-file-types' keys."
+  (delete-dups (mapcar #'car denote-file-types)))
+
+(defun denote--get-title-line-from-front-matter (title file-type)
+  "Retrieve title line from front matter based on FILE-TYPE.
+Format TITLE in the title line.  The returned line does not
+contain the newline."
+  (let ((front-matter (denote--format-front-matter title "" nil "" file-type))
+        (key-regexp (denote--title-key-regexp file-type)))
+    (with-temp-buffer
+      (insert front-matter)
+      (goto-char (point-min))
+      (when (re-search-forward key-regexp nil t 1)
+        (buffer-substring-no-properties (line-beginning-position) (line-end-position))))))
+
+(defun denote--get-keywords-line-from-front-matter (keywords file-type)
+  "Retrieve keywords line from front matter based on FILE-TYPE.
+Format KEYWORDS in the keywords line.  The returned line does not
+contain the newline."
+  (let ((front-matter (denote--format-front-matter "" "" keywords "" file-type))
+        (key-regexp (denote--keywords-key-regexp file-type)))
+    (with-temp-buffer
+      (insert front-matter)
+      (goto-char (point-min))
+      (when (re-search-forward key-regexp nil t 1)
+        (buffer-substring-no-properties (line-beginning-position) (line-end-position))))))
+
+;;;; Front matter or content retrieval functions
+
+(defun denote-retrieve-filename-identifier (file)
+  "Extract identifier from FILE name.
+To return an existing identifier or create a new one, refer to
+the function `denote-retrieve-or-create-file-identifier'."
+  (if (denote-file-has-identifier-p file)
+      (progn
+        (string-match denote-id-regexp file)
+        (match-string 0 file))
+    (error "Cannot find `%s' as a file with a Denote identifier" file)))
+
+(define-obsolete-function-alias
+  'denote--retrieve-filename-identifier
+  'denote-retrieve-filename-identifier
+  "1.0.0")
+
+(defun denote-retrieve-or-create-file-identifier (file &optional date files)
+  "Return FILE identifier, generating one if appropriate.
+
+The conditions are as follows:
+
+- If FILE has an identifier, return it.
+
+- If FILE does not have an identifier and optional DATE is
+  non-nil, invoke `denote-prompt-for-date-return-id'.
+
+- If FILE does not have an identifier and DATE is nil, use the
+  file attributes to determine the last modified date and format
+  it as an identifier.
+
+- As a fallback, derive an identifier from the current time.
+
+With optional FILES as a list of file names, test that the
+identifier is unique among them.
+
+With optional FILES as non-nil, test that the identifier is
+unique among all files and buffers in variable
+`denote-directory'.
+
+To only return an existing identifier, refer to the function
+`denote-retrieve-filename-identifier'."
+  (let ((id
+         (cond
+          ((string-match denote-id-regexp file)
+           (substring file (match-beginning 0) (match-end 0)))
+          (date (denote-prompt-for-date-return-id))
+          ((denote--file-attributes-time file))
+          (t (format-time-string denote-id-format)))))
+    (cond
+     ((and files (listp files))
+      (denote--return-new-identifier-if-duplicate id files))
+     ((and files (not (denote-file-has-identifier-p file)))
+      (denote--return-new-identifier-if-duplicate id))
+     (t
+      id))))
+
+(define-obsolete-function-alias
+  'denote--file-name-id
+  'denote-retrieve-or-create-file-identifier
+  "1.0.0")
+
+(defun denote-retrieve-filename-signature (file)
+  "Extract signature from FILE name, if present, else return nil."
+  (when (denote-file-has-signature-p file)
+    (string-match denote-signature-regexp file)
+    (match-string 1 file)))
+
+(defun denote-retrieve-filename-title (file)
+  "Extract title from FILE name, else return `file-name-base'.
+Run `denote-desluggify' on title if the extraction is sucessful."
+  (if-let* (((file-exists-p file))
+            ((denote-file-has-identifier-p file))
+            ((string-match denote-title-regexp file))
+            (title (match-string 1 file)))
+      (denote-desluggify title)
+    (file-name-base file)))
+
+(define-obsolete-function-alias
+  'denote--retrieve-filename-title
+  'denote-retrieve-filename-title
+  "1.0.0")
+
+(defun denote-retrieve-title-value (file file-type)
+  "Return title value from FILE front matter per FILE-TYPE."
+  (with-temp-buffer
+    (insert-file-contents file)
+    (goto-char (point-min))
+    (when (re-search-forward (denote--title-key-regexp file-type) nil t 1)
+      (funcall (denote--title-value-reverse-function file-type)
+               (buffer-substring-no-properties (point) (line-end-position))))))
+
+(define-obsolete-function-alias
+  'denote--retrieve-title-value
+  'denote-retrieve-title-value
+  "1.0.0")
+
+(defun denote-retrieve-title-line (file file-type)
+  "Return title line from FILE front matter per FILE-TYPE."
+  (with-temp-buffer
+    (insert-file-contents file)
+    (goto-char (point-min))
+    (when (re-search-forward (denote--title-key-regexp file-type) nil t 1)
+      (buffer-substring-no-properties (line-beginning-position) (line-end-position)))))
+
+(define-obsolete-function-alias
+  'denote--retrieve-title-line
+  'denote-retrieve-title-line
+  "1.0.0")
+
+(defun denote-retrieve-keywords-value (file file-type)
+  "Return keywords value from FILE front matter per FILE-TYPE."
+  (with-temp-buffer
+    (insert-file-contents file)
+    (goto-char (point-min))
+    (when (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
+      (funcall (denote--keywords-value-reverse-function file-type)
+               (buffer-substring-no-properties (point) (line-end-position))))))
+
+(define-obsolete-function-alias
+  'denote--retrieve-keywords-value
+  'denote-retrieve-keywords-value
+  "1.0.0")
+
+(defun denote-retrieve-keywords-line (file file-type)
+  "Return keywords line from FILE front matter per FILE-TYPE."
+  (with-temp-buffer
+    (insert-file-contents file)
+    (goto-char (point-min))
+    (when (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
+      (buffer-substring-no-properties (line-beginning-position) (line-end-position)))))
+
+(define-obsolete-function-alias
+  'denote--retrieve-keywords-line
+  'denote-retrieve-keywords-line
+  "1.0.0")
+
+(defun denote--retrieve-title-or-filename (file type)
+  "Return appropriate title for FILE given its TYPE."
+  (if-let (((denote-file-is-note-p file))
+           (title (denote-retrieve-title-value file type))
+           ((not (string-blank-p title))))
+      title
+    (denote-retrieve-filename-title file)))
+
+(defun denote--retrieve-location-in-xrefs (identifier)
+  "Return list of xrefs for IDENTIFIER with their respective location.
+Limit the search to text files, per `denote-directory-text-only-files'."
+  (mapcar #'xref-match-item-location
+          (xref-matches-in-files identifier
+                                 (denote-directory-text-only-files))))
+
+(defun denote--retrieve-group-in-xrefs (identifier)
+  "Access location of xrefs for IDENTIFIER and group them per file.
+See `denote--retrieve-locations-in-xrefs'."
+  (mapcar #'xref-location-group
+          (denote--retrieve-location-in-xrefs identifier)))
+
+(defun denote--retrieve-files-in-xrefs (identifier)
+  "Return sorted, deduplicated file names with IDENTIFIER in their contents."
+  (sort
+   (delete-dups
+    (denote--retrieve-group-in-xrefs identifier))
+   #'string-lessp))
+
+;;;; New note
+
+;;;;; Common helpers for new notes
+
+(defun denote-format-file-name (path id keywords title-slug extension &optional signature)
+  "Format file name.
+PATH, ID, KEYWORDS, TITLE-SLUG, EXTENSION and optional SIGNATURE
+are expected to be supplied by `denote' or equivalent command."
+  (let ((kws (denote--keywords-combine keywords))
+        (file-name (concat path id)))
+    (when (and signature (not (string-empty-p signature)))
+      (setq file-name (concat file-name "==" signature)))
+    (when (and title-slug (not (string-empty-p title-slug)))
+      (setq file-name (concat file-name "--" title-slug)))
+    (when (and keywords (not (string-blank-p kws)))
+      (setq file-name (concat file-name "__" kws)))
+    (concat file-name extension)))
+
+(define-obsolete-function-alias
+  'denote--format-file
+  'denote-format-file-name
+  "1.0.0")
+
+(defun denote--format-front-matter-title (title file-type)
+  "Format TITLE according to FILE-TYPE for the file's front matter."
+  (funcall (denote--title-value-function file-type) title))
+
+(defun denote--format-front-matter-keywords (keywords file-type)
+  "Format KEYWORDS according to FILE-TYPE for the file's front matter.
+Apply `downcase' to KEYWORDS."
+  (let ((kw (mapcar #'downcase (denote-sluggify-keywords keywords))))
+    (funcall (denote--keywords-value-function file-type) kw)))
+
+(make-obsolete-variable 'denote-text-front-matter-delimiter nil "0.6.0")
+
+(defun denote--format-front-matter (title date keywords id filetype)
+  "Front matter for new notes.
+
+TITLE, DATE, and ID are all strings or functions that return a
+string.  KEYWORDS is a list of strings.  FILETYPE is one of the
+values of `denote-file-type'."
+  (let* ((fm (denote--front-matter filetype))
+         (title (denote--format-front-matter-title title filetype))
+         (kws (denote--format-front-matter-keywords keywords filetype)))
+    (if fm (format fm title date kws id) "")))
+
+(defun denote--path (title keywords dir id file-type &optional signature)
+  "Return path to new file.
+Use ID, TITLE, KEYWORDS, FILE-TYPE and optional SIGNATURE to
+construct path to DIR."
+  (denote-format-file-name
+   dir id
+   (denote-sluggify-keywords keywords)
+   (denote-sluggify title)
+   (denote--file-extension file-type)
+   (when signature
+     (denote-sluggify-signature signature))))
+
+;; Adapted from `org-hugo--org-date-time-to-rfc3339' in the `ox-hugo'
+;; package: <https://github.com/kaushalmodi/ox-hugo>.
+(defun denote-date-rfc3339 (date)
+  "Format DATE using the RFC3339 specification."
+  (replace-regexp-in-string
+   "\\([0-9]\\{2\\}\\)\\([0-9]\\{2\\}\\)\\'" "\\1:\\2"
+   (format-time-string "%FT%T%z" date)))
+
+(define-obsolete-function-alias
+  'denote--date-rfc3339
+  'denote-date-rfc3339
+  "1.2.0")
+
+(defun denote-date-org-timestamp (date)
+  "Format DATE using the Org inactive timestamp notation."
+  (format-time-string "[%F %a %R]" date))
+
+(define-obsolete-function-alias
+  'denote--date-org-timestamp
+  'denote-date-org-timestamp
+  "1.2.0")
+
+(defun denote-date-iso-8601 (date)
+  "Format DATE according to ISO 8601 standard."
+  (format-time-string "%F" date))
+
+(define-obsolete-function-alias
+  'denote--date-iso-8601
+  'denote-date-iso-8601
+  "1.2.0")
+
+(defun denote--date (date file-type)
+  "Expand DATE in an appropriate format for FILE-TYPE."
+  (let ((format denote-date-format))
+    (cond
+     ((stringp format)
+      (format-time-string format date))
+     ((when-let ((fn (denote--date-format-function file-type)))
+        (funcall fn date)))
+     (t
+      (denote-date-org-timestamp date)))))
+
+(defun denote--prepare-note (title keywords date id directory file-type template &optional signature)
+  "Prepare a new note file.
+
+Arguments TITLE, KEYWORDS, DATE, ID, DIRECTORY, FILE-TYPE,
+TEMPLATE, and optional SIGNATURE should be valid for note
+creation."
+  (let* ((path (denote--path title keywords directory id file-type signature))
+         (buffer (find-file path))
+         (header (denote--format-front-matter
+                  title (denote--date date file-type) keywords
+                  (format-time-string denote-id-format date)
+                  file-type)))
+    (with-current-buffer buffer
+      (insert header)
+      (insert template))))
+
+(defun denote--dir-in-denote-directory-p (directory)
+  "Return DIRECTORY if in variable `denote-directory', else nil."
+  (when (and directory
+             (string-prefix-p (denote-directory)
+                              (expand-file-name directory)))
+    directory))
+
+(defun denote--valid-file-type (filetype)
+  "Return a valid filetype given the argument FILETYPE.
+If none is found, the first element of `denote-file-types' is
+returned."
+  (unless (or (symbolp filetype) (stringp filetype))
+    (user-error "`%s' is not a symbol or string" filetype))
+  (when (stringp filetype)
+    (setq filetype (intern filetype)))
+  (if (memq filetype (mapcar 'car denote-file-types))
+      filetype
+    (caar denote-file-types)))
+
+(defun denote--date-add-current-time (date)
+  "Add current time to DATE, if necessary.
+The idea is to turn 2020-01-15 into 2020-01-15 16:19 so that the
+hour and minute component is not left to 00:00.
+
+This reduces the burden on the user who would otherwise need to
+input that value in order to avoid the error of duplicate
+identifiers.
+
+It also addresses a difference between Emacs 28 and Emacs 29
+where the former does not read dates without a time component."
+  (if (<= (length date) 10)
+      (format "%s %s" date (format-time-string "%H:%M:%S" (current-time)))
+    date))
+
+(defun denote--valid-date (date)
+  "Return DATE if parsed by `date-to-time', else signal error."
+  (let ((datetime (denote--date-add-current-time date)))
+    (date-to-time datetime)))
+
+(defun denote--buffer-file-names ()
+  "Return file names of Denote buffers."
+  (delq nil
+        (mapcar
+         (lambda (buffer)
+           (when-let (((buffer-live-p buffer))
+                      (file (buffer-file-name buffer))
+                      ((denote-file-is-note-p file)))
+             file))
+         (buffer-list))))
+
+;; In normal usage, this should only be relevant for `denote-date',
+;; otherwise the identifier is always unique (we trust that no-one
+;; writes multiple notes within fractions of a second).  Though the
+;; `denote' command does call `denote-barf-duplicate-id'.
+(defun denote--id-exists-p (identifier &optional files)
+  "Return non-nil if IDENTIFIER already exists.
+With optional FILES, check for IDENTIFIER among them.  Else refer
+to files or buffers in the variable `denote-directory'."
+  (seq-some
+   (lambda (file)
+     (string-prefix-p identifier (file-name-nondirectory file)))
+   (or files
+       (append (denote-directory-files) (denote--buffer-file-names)))))
+
+(defun denote--increment-identifier (identifier)
+  "Increment IDENTIFIER.
+Preserve the date component and append to it the current time."
+  (let* ((datetime (split-string identifier "T"))
+         (date (car datetime)))
+    (concat date "T" (format-time-string "%H%M%S"))))
+
+(defun denote--return-new-identifier-if-duplicate (identifier &optional files)
+  "Return new unique identifier if IDENTIFIER already exists.
+The meaning of FILES is the same as in `denote--id-exists-p'."
+  (while (denote--id-exists-p identifier files)
+    (setq identifier (denote--increment-identifier identifier)))
+  identifier)
+
+(defun denote-barf-duplicate-id (identifier)
+  "Throw a `user-error' if IDENTIFIER already exists."
+  (when (denote--id-exists-p identifier)
+    (user-error "`%s' already exists; aborting new note creation" identifier)))
+
+(define-obsolete-function-alias
+  'denote--barf-duplicate-id
+  'denote-barf-duplicate-id
+  "1.0.0")
+
+;;;;; The `denote' command and its prompts
+
+;;;###autoload
+(defun denote (&optional title keywords file-type subdirectory date template signature)
+  "Create a new note with the appropriate metadata and file name.
+
+When called interactively, the metadata and file name are prompted
+according to the value of `denote-prompts'.
+
+When called from Lisp, all arguments are optional.
+
+- TITLE is a string or a function returning a string.
+
+- KEYWORDS is a list of strings.  The list can be empty or the
+  value can be set to nil.
+
+- FILE-TYPE is a symbol among those described in `denote-file-type'.
+
+- SUBDIRECTORY is a string representing the path to either the
+  value of the variable `denote-directory' or a subdirectory
+  thereof.  The subdirectory must exist: Denote will not create
+  it.  If SUBDIRECTORY does not resolve to a valid path, the
+  variable `denote-directory' is used instead.
+
+- DATE is a string representing a date like 2022-06-30 or a date
+  and time like 2022-06-16 14:30.  A nil value or an empty string
+  is interpreted as the `current-time'.
+
+- TEMPLATE is a symbol which represents the key of a cons cell in
+  the user option `denote-templates'.  The value of that key is
+  inserted to the newly created buffer after the front matter.
+
+- SIGNATURE is a string or a function returning a string."
+  (interactive
+   (let ((args (make-vector 7 nil)))
+     (dolist (prompt denote-prompts)
+       (pcase prompt
+         ('title (aset args 0 (denote-title-prompt
+                               (when (use-region-p)
+                                 (buffer-substring-no-properties
+                                  (region-beginning)
+                                  (region-end))))))
+         ('keywords (aset args 1 (denote-keywords-prompt)))
+         ('file-type (aset args 2 (denote-file-type-prompt)))
+         ('subdirectory (aset args 3 (denote-subdirectory-prompt)))
+         ('date (aset args 4 (denote-date-prompt)))
+         ('template (aset args 5 (denote-template-prompt)))
+         ('signature (aset args 6 (denote-signature-prompt)))))
+     (append args nil)))
+  (let* ((title (or title ""))
+         (file-type (denote--valid-file-type (or file-type denote-file-type)))
+         (kws (if (called-interactively-p 'interactive)
+                  keywords
+                (denote-keywords-sort keywords)))
+         (date (if (or (null date) (string-empty-p date))
+                   (current-time)
+                 (denote--valid-date date)))
+         (id (format-time-string denote-id-format date))
+         (directory (if (denote--dir-in-denote-directory-p subdirectory)
+                        (file-name-as-directory subdirectory)
+                      (denote-directory)))
+         (template (if (stringp template)
+                       template
+                     (or (alist-get template denote-templates) "")))
+         (signature (or signature "")))
+    (denote-barf-duplicate-id id)
+    (denote--prepare-note title kws date id directory file-type template signature)
+    (denote--keywords-add-to-history keywords)))
+
+(defvar denote--title-history nil
+  "Minibuffer history of `denote-title-prompt'.")
+
+(defun denote-title-prompt (&optional default-title)
+  "Read file title for `denote'.
+With optional DEFAULT-TITLE use it as the default value."
+  (let* ((def default-title)
+         (format (if (and def (not (string-empty-p def)))
+                     (format "File title [%s]: " def)
+                   "File title: ")))
+    (read-string format nil 'denote--title-history def)))
+
+(define-obsolete-function-alias
+  'denote--title-prompt
+  'denote-title-prompt
+  "1.0.0")
+
+(defvar denote--file-type-history nil
+  "Minibuffer history of `denote-file-type-prompt'.")
+
+(defun denote-file-type-prompt ()
+  "Prompt for `denote-file-type'.
+Note that a non-nil value other than `text', `markdown-yaml', and
+`markdown-toml' falls back to an Org file type.  We use `org'
+here for clarity."
+  (completing-read
+   "Select file type: " (denote--file-type-keys) nil t
+   nil 'denote--file-type-history))
+
+(define-obsolete-function-alias
+  'denote--file-type-prompt
+  'denote-file-type-prompt
+  "1.0.0")
+
+(defvar denote--date-history nil
+  "Minibuffer history of `denote-date-prompt'.")
+
+(declare-function org-read-date "org" (&optional with-time to-time from-string prompt default-time default-input inactive))
+
+(defun denote-date-prompt ()
+  "Prompt for date, expecting YYYY-MM-DD or that plus HH:MM.
+Use Org's more advanced date selection utility if the user option
+`denote-date-prompt-use-org-read-date' is non-nil."
+  (if (and denote-date-prompt-use-org-read-date
+           (require 'org nil :no-error))
+      (let* ((time (org-read-date nil t))
+             (org-time-seconds (format-time-string "%S" time))
+             (cur-time-seconds (format-time-string "%S" (current-time))))
+        ;; When the user does not input a time, org-read-date defaults to 00 for seconds.
+        ;; When the seconds are 00, we add the current seconds to avoid identifier collisions.
+        (when (string-equal "00" org-time-seconds)
+          (setq time (time-add time (string-to-number cur-time-seconds))))
+        (format-time-string "%Y-%m-%d %H:%M:%S" time))
+    (read-string
+     "DATE and TIME for note (e.g. 2022-06-16 14:30): "
+     nil 'denote--date-history)))
+
+(define-obsolete-function-alias
+  'denote--date-prompt
+  'denote-date-prompt
+  "1.0.0")
+
+(defun denote-prompt-for-date-return-id ()
+  "Use `denote-date-prompt' and return it as `denote-id-format'."
+  (format-time-string
+   denote-id-format
+   (denote--valid-date (denote-date-prompt))))
+
+(defvar denote--subdir-history nil
+  "Minibuffer history of `denote-subdirectory-prompt'.")
+
+;; Making it a completion table is useful for packages that read the
+;; metadata, such as `marginalia' and `embark'.
+(defun denote--subdirs-completion-table (dirs)
+  "Match DIRS as a completion table."
+  (let* ((def (car denote--subdir-history))
+         (table (denote--completion-table 'file dirs))
+         (prompt (if def
+                     (format "Select subdirectory [%s]: " def)
+                   "Select subdirectory: ")))
+    (completing-read prompt table nil t nil 'denote--subdir-history def)))
+
+(defun denote-subdirectory-prompt ()
+  "Prompt for subdirectory of the variable `denote-directory'.
+The table uses the `file' completion category (so it works with
+packages such as `marginalia' and `embark')."
+  (let* ((root (directory-file-name (denote-directory)))
+         (subdirs (denote-directory-subdirectories))
+         (dirs (push root subdirs)))
+    (denote--subdirs-completion-table dirs)))
+
+(define-obsolete-function-alias
+  'denote--subdirs-prompt
+  'denote-subdirectory-prompt
+  "1.0.0")
+
+(defvar denote--template-history nil
+  "Minibuffer history of `denote-template-prompt'.")
+
+(defun denote-template-prompt ()
+  "Prompt for template key in `denote-templates' and return its value."
+  (let ((templates denote-templates))
+    (alist-get
+     (intern
+      (completing-read
+       "Select template KEY: " (mapcar #'car templates)
+       nil t nil 'denote--template-history))
+     templates)))
+
+(define-obsolete-function-alias
+  'denote--template-prompt
+  'denote-template-prompt
+  "1.0.0")
+
+(defvar denote--signature-history nil
+  "Minibuffer history of `denote-signature-prompt'.")
+
+(defun denote-signature-prompt ()
+  "Prompt for signature string."
+  (read-string "Provide signature: " nil 'denote--signature-history))
+
+;;;;; Convenience commands as `denote' variants
+
+(defalias 'denote-create-note 'denote
+  "Alias for `denote' command.")
+
+;;;###autoload
+(defun denote-type ()
+  "Create note while prompting for a file type.
+
+This is the equivalent to calling `denote' when `denote-prompts'
+is set to \\='(file-type title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(file-type title keywords)))
+    (call-interactively #'denote)))
+
+(defalias 'denote-create-note-using-type 'denote-type
+  "Alias for `denote-type' command.")
+
+;;;###autoload
+(defun denote-date ()
+  "Create note while prompting for a date.
+
+The date can be in YEAR-MONTH-DAY notation like 2022-06-30 or
+that plus the time: 2022-06-16 14:30.  When the user option
+`denote-date-prompt-use-org-read-date' is non-nil, the date
+prompt uses the more powerful Org+calendar system.
+
+This is the equivalent to calling `denote' when `denote-prompts'
+is set to \\='(date title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(date title keywords)))
+    (call-interactively #'denote)))
+
+(defalias 'denote-create-note-using-date 'denote-date
+  "Alias for `denote-date' command.")
+
+;;;###autoload
+(defun denote-subdirectory ()
+  "Create note while prompting for a subdirectory.
+
+Available candidates include the value of the variable
+`denote-directory' and any subdirectory thereof.
+
+This is equivalent to calling `denote' when `denote-prompts' is
+set to \\='(subdirectory title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(subdirectory title keywords)))
+    (call-interactively #'denote)))
+
+(defalias 'denote-create-note-in-subdirectory 'denote-subdirectory
+  "Alias for `denote-subdirectory' command.")
+
+;;;###autoload
+(defun denote-template ()
+  "Create note while prompting for a template.
+
+Available candidates include the keys in the `denote-templates'
+alist.  The value of the selected key is inserted in the newly
+created note after the front matter.
+
+This is equivalent to calling `denote' when `denote-prompts' is
+set to \\='(template title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(template title keywords)))
+    (call-interactively #'denote)))
+
+(defalias 'denote-create-note-with-template 'denote-template
+  "Alias for `denote-template' command.")
+
+;;;###autoload
+(defun denote-signature ()
+  "Create note while prompting for a file signature.
+
+This is the equivalent to calling `denote' when `denote-prompts'
+is set to \\='(signature title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(signature title keywords)))
+    (call-interactively #'denote)))
+
+(defalias 'denote-create-note-using-signature 'denote-signature
+  "Alias for `denote-signature' command.")
+
+;;;;; Other convenience commands
+
+(defun denote--extract-title-from-file-history ()
+  "Extract last file title input from `file-name-history'."
+  ;; We do not need to check if `file-name-history' is initialised
+  ;; because it is defined in files.el.  My understanding is that it
+  ;; is always loaded.
+  (when-let ((title (expand-file-name (car denote--file-history))))
+    (string-match (denote-directory) title)
+    (substring title (match-end 0))))
+
+(defun denote--append-extracted-string-to-history (history)
+  "Append `denote--extract-title-from-file-history' to HISTORY."
+  (append
+   (list (denote--extract-title-from-file-history))
+   history))
+
+(defun denote--command-with-title-history (command)
+  "Call COMMAND with modified title history.
+Allow COMMAND to gain access to the return value of
+`denote--append-extracted-string-to-history' for the
+`denote--title-history'.  This is what makes
+`denote-open-or-create' and `denote-link-or-create' return the
+last input on demand when prompting for a title."
+  (let ((denote--title-history
+         (denote--append-extracted-string-to-history denote--title-history)))
+    (call-interactively command)))
+
+;;;###autoload
+(defun denote-open-or-create (target)
+  "Visit TARGET file in variable `denote-directory'.
+If file does not exist, invoke `denote' to create a file.
+
+If TARGET file does not exist, add the user input that was used
+to search for it to the minibuffer history of the
+`denote-file-prompt'.  The user can then retrieve and possibly
+further edit their last input, using it as the newly created
+note's actual title.  At the `denote-file-prompt' type
+\\<minibuffer-local-map>\\[previous-history-element]."
+  (interactive (list (denote-file-prompt)))
+  (if (and target (file-exists-p target))
+      (find-file target)
+    (denote--command-with-title-history #'denote)))
+
+;;;###autoload
+(defun denote-keywords-add (keywords)
+  "Prompt for KEYWORDS to add to the current note's front matter.
+When called from Lisp, KEYWORDS is a list of strings.
+
+Rename the file without further prompt so that its name reflects
+the new front matter, per `denote-rename-file-using-front-matter'."
+  (interactive (list (denote-keywords-prompt)))
+  ;; A combination of if-let and let, as we need to take into account
+  ;; the scenario in which there are no keywords yet.
+  (if-let* ((file (buffer-file-name))
+            ((denote-file-is-note-p file))
+            (file-type (denote-filetype-heuristics file)))
+      (let* ((cur-keywords (denote-retrieve-keywords-value file file-type))
+             (new-keywords (if (and (stringp cur-keywords)
+                                    (string-blank-p cur-keywords))
+                               keywords
+                             (denote-keywords-sort
+                              (seq-uniq (append keywords cur-keywords))))))
+        (denote-rewrite-keywords file new-keywords file-type)
+        (denote-rename-file-using-front-matter file t))
+    (user-error "Buffer not visiting a Denote file")))
+
+(defun denote--keywords-delete-prompt (keywords)
+  "Prompt for one or more KEYWORDS.
+In the case of multiple entries, those are separated by the
+`crm-sepator', which typically is a comma.  In such a case, the
+output is sorted with `string-lessp'."
+  (let ((choice (denote--keywords-crm keywords "Keyword to remove: ")))
+    (if denote-sort-keywords
+        (sort choice #'string-lessp)
+      choice)))
+
+;;;###autoload
+(defun denote-keywords-remove ()
+  "Prompt for keywords in current note and remove them.
+Keywords are retrieved from the file's front matter.
+
+Rename the file without further prompt so that its name reflects
+the new front matter, per `denote-rename-file-using-front-matter'."
+  (declare (interactive-only t))
+  (interactive)
+  (if-let* ((file (buffer-file-name))
+            ((denote-file-is-note-p file))
+            (file-type (denote-filetype-heuristics file)))
+      (when-let* ((cur-keywords (denote-retrieve-keywords-value file file-type))
+                  ((or (listp cur-keywords) (not (string-blank-p cur-keywords))))
+                  (del-keyword (denote--keywords-delete-prompt cur-keywords)))
+        (denote-rewrite-keywords
+         file
+         (seq-difference cur-keywords del-keyword)
+         file-type)
+        (denote-rename-file-using-front-matter file t))
+    (user-error "Buffer not visiting a Denote file")))
+
+;;;; Note modification
+
+;;;;; Common helpers for note modifications
+
+(defun denote--file-types-with-extension (extension)
+  "Return only the entries of `denote-file-types' with EXTENSION.
+See the format of `denote-file-types'."
+  (seq-filter (lambda (type)
+                (string-equal (plist-get (cdr type) :extension) extension))
+              denote-file-types))
+
+(defun denote-filetype-heuristics (file)
+  "Return likely file type of FILE.
+Use the file extension to detect the file type of the file.
+
+If more than one file type correspond to this file extension, use
+the first file type for which the key-title-kegexp matches in the
+file or, if none matches, use the first type with this file
+extension in `denote-file-type'.
+
+If no file types in `denote-file-types' has the file extension,
+the file type is assumed to be the first of `denote-file-types'."
+  (let* ((file-type)
+         (extension (file-name-extension file t))
+         (types (denote--file-types-with-extension extension)))
+    (cond ((not types)
+           (setq file-type (caar denote-file-types)))
+          ((= (length types) 1)
+           (setq file-type (caar types)))
+          (t
+           (if-let ((found-type
+                     (seq-find
+                      (lambda (type)
+                        (denote--regexp-in-file-p (plist-get (cdr type) :title-key-regexp) file))
+                      types)))
+               (setq file-type (car found-type))
+             (setq file-type (caar types)))))
+    file-type))
+
+(define-obsolete-function-alias
+  'denote--filetype-heuristics
+  'denote-filetype-heuristics
+  "1.0.0")
+
+(defun denote--file-attributes-time (file)
+  "Return `file-attribute-modification-time' of FILE as identifier."
+  (format-time-string
+   denote-id-format
+   (file-attribute-modification-time (file-attributes file))))
+
+(defun denote-update-dired-buffers ()
+  "Update Dired buffers of variable `denote-directory'."
+  (mapc
+   (lambda (buf)
+     (with-current-buffer buf
+       (when (and (eq major-mode 'dired-mode)
+                  (denote--default-dir-has-denote-prefix))
+         (revert-buffer))))
+   (buffer-list)))
+
+(defun denote--rename-buffer (old-name new-name)
+  "Rename OLD-NAME buffer to NEW-NAME, when appropriate."
+  (when-let ((buffer (find-buffer-visiting old-name)))
+    (with-current-buffer buffer
+      (set-visited-file-name new-name nil t))))
+
+(defun denote-rename-file-and-buffer (old-name new-name)
+  "Rename file named OLD-NAME to NEW-NAME, updating buffer name."
+  (unless (string= (expand-file-name old-name) (expand-file-name new-name))
+    (cond
+     ((derived-mode-p 'dired-mode)
+      (dired-rename-file old-name new-name nil))
+     ((vc-backend old-name)
+      (vc-rename-file old-name new-name))
+     (t
+      (rename-file old-name new-name nil)))
+    (denote--rename-buffer old-name new-name)))
+
+(define-obsolete-function-alias
+  'denote--rename-file
+  'denote-rename-file-and-buffer
+  "1.0.0")
+
+(defun denote--add-front-matter (file title keywords id file-type)
+  "Prepend front matter to FILE if `denote-file-is-note-p'.
+The TITLE, KEYWORDS ID, and FILE-TYPE are passed from the
+renaming command and are used to construct a new front matter
+block if appropriate."
+  (when-let* ((date (denote--date (date-to-time id) file-type))
+              (new-front-matter (denote--format-front-matter title date keywords id file-type)))
+    (with-current-buffer (find-file-noselect file)
+      (goto-char (point-min))
+      (insert new-front-matter))))
+
+(defun denote--regexp-in-file-p (regexp file)
+  "Return t if REGEXP matches in the FILE."
+  (with-temp-buffer
+    (insert-file-contents file)
+    (goto-char (point-min))
+    (re-search-forward regexp nil t 1)))
+
+(defun denote--edit-front-matter-p (file file-type)
+  "Test if FILE should be subject to front matter rewrite.
+Use FILE-TYPE to look for the front matter lines.  This is
+relevant for operations that insert or rewrite the front matter
+in a Denote note.
+
+For the purposes of this test, FILE is a Denote note when it
+contains a title line, a keywords line or both."
+  (and (denote--regexp-in-file-p (denote--title-key-regexp file-type) file)
+       (denote--regexp-in-file-p (denote--keywords-key-regexp file-type) file)))
+
+(defun denote-rewrite-keywords (file keywords file-type)
+  "Rewrite KEYWORDS in FILE outright according to FILE-TYPE.
+
+Do the same as `denote-rewrite-front-matter' for keywords,
+but do not ask for confirmation.
+
+This is for use in `denote-keywords-add',`denote-keywords-remove',
+`denote-dired-rename-marked-files', or related."
+  (with-current-buffer (find-file-noselect file)
+    (save-excursion
+      (save-restriction
+        (widen)
+        (goto-char (point-min))
+        (when (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
+          (goto-char (line-beginning-position))
+          (insert (denote--get-keywords-line-from-front-matter keywords file-type))
+          (delete-region (point) (line-end-position)))))))
+
+(define-obsolete-function-alias
+  'denote--rewrite-keywords
+  'denote-rewrite-keywords
+  "2.0.0")
+
+(defun denote-rewrite-front-matter (file title keywords file-type)
+  "Rewrite front matter of note after `denote-rename-file'.
+The FILE, TITLE, KEYWORDS, and FILE-TYPE are given by the
+renaming command and are used to construct new front matter
+values if appropriate."
+  (when-let* ((old-title-line (denote-retrieve-title-line file file-type))
+              (old-keywords-line (denote-retrieve-keywords-line file file-type))
+              (new-title-line (denote--get-title-line-from-front-matter title file-type))
+              (new-keywords-line (denote--get-keywords-line-from-front-matter keywords file-type)))
+    (with-current-buffer (find-file-noselect file)
+      (when (y-or-n-p (format
+                       "Replace front matter?\n-%s\n+%s\n\n-%s\n+%s?"
+                       (propertize old-title-line 'face 'error)
+                       (propertize new-title-line 'face 'success)
+                       (propertize old-keywords-line 'face 'error)
+                       (propertize new-keywords-line 'face 'success)))
+        (save-excursion
+          (save-restriction
+            (widen)
+            (goto-char (point-min))
+            (re-search-forward (denote--title-key-regexp file-type) nil t 1)
+            (goto-char (line-beginning-position))
+            (insert new-title-line)
+            (delete-region (point) (line-end-position))
+            (goto-char (point-min))
+            (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
+            (goto-char (line-beginning-position))
+            (insert new-keywords-line)
+            (delete-region (point) (line-end-position))))))))
+
+(define-obsolete-function-alias
+  'denote--rewrite-front-matter
+  'denote-rewrite-front-matter
+  "2.0.0")
+
+;;;;; The renaming commands and their prompts
+
+(defun denote--rename-dired-file-or-prompt ()
+  "Return Dired file at point, else prompt for one.
+Throw error is FILE is not regular, else return FILE."
+  (or (dired-get-filename nil t)
+      (let* ((file (buffer-file-name))
+             (format (if file
+                         (format "Rename file Denote-style [%s]: " file)
+                       "Rename file Denote-style: "))
+             (selected-file (read-file-name format nil file t nil)))
+        (if (or (file-directory-p selected-file)
+                (not (file-regular-p selected-file)))
+            (user-error "Only rename regular files")
+          selected-file))))
+
+(defun denote-rename-file-prompt (old-name new-name)
+  "Prompt to rename file named OLD-NAME to NEW-NAME."
+  (unless (string= (expand-file-name old-name) (expand-file-name new-name))
+    (y-or-n-p
+     (format "Rename %s to %s?"
+             (propertize (file-name-nondirectory old-name) 'face 'error)
+             (propertize (file-name-nondirectory new-name) 'face 'success)))))
+
+(define-obsolete-function-alias
+  'denote--rename-file-prompt
+  'denote-rename-file-prompt
+  "1.0.0")
+
+;;;###autoload
+(defun denote-rename-file (file title keywords &optional date)
+  "Rename file and update existing front matter if appropriate.
+
+If in Dired, consider FILE to be the one at point, else prompt
+with minibuffer completion for one.
+
+If FILE has a Denote-compliant identifier, retain it while
+updating the TITLE and KEYWORDS fields of the file name.  Else
+create an identifier based on the following conditions:
+
+- If FILE does not have an identifier and optional DATE is
+  non-nil (such as with a prefix argument), invoke the function
+  `denote-prompt-for-date-return-id'.  It prompts for a date and
+  uses it to derive the identifier.
+
+- If FILE does not have an identifier and optional DATE is
+  nil (this is the case without a prefix argument), use the file
+  attributes to determine the last modified date and format it as
+  an identifier.
+
+- As a fallback, derive an identifier from the current time.
+
+- If the resulting identifier is not unique among the files in
+  the variable `denote-directory', increment it such that it
+  becomes unique.
+
+The default TITLE is retrieved from a line starting with a title
+field in the file's contents, depending on the given file
+type (e.g. #+title for Org).  Else, the file name is used as a
+default value at the minibuffer prompt.
+
+As a final step after the FILE, TITLE, and KEYWORDS prompts, ask
+for confirmation, showing the difference between old and new file
+names.
+
+The file type extension (like .txt) is read from the underlying
+file and is preserved through the renaming process.  Files that
+have no extension are simply left without one.
+
+Renaming only occurs relative to the current directory.  Files
+are not moved between directories.
+
+If the FILE has Denote-style front matter for the TITLE and
+KEYWORDS, ask to rewrite their values in order to reflect the new
+input (this step always requires confirmation and the underlying
+buffer is not saved, so consider invoking `diff-buffer-with-file'
+to double-check the effect).  The rewrite of the FILE and
+KEYWORDS in the front matter should not affect the rest of the
+block.
+
+If the file doesn't have front matter but is among the supported
+file types (per `denote-file-type'), add front matter at the top
+of it and leave the buffer unsaved for further inspection.
+
+For per-file-type front matter, refer to the variables:
+
+- `denote-org-front-matter'
+- `denote-text-front-matter'
+- `denote-toml-front-matter'
+- `denote-yaml-front-matter'
+
+This command is intended to (i) rename existing Denote notes
+while updating their title and keywords in the front matter, (ii)
+convert existing supported file types to Denote notes, and (ii)
+rename non-note files (e.g. PDF) that can benefit from Denote's
+file-naming scheme.  The latter is a convenience we provide,
+since we already have all the requisite mechanisms in
+place (though Denote does not---and will not---manage such
+files)."
+  (interactive
+   (let* ((file (denote--rename-dired-file-or-prompt))
+          (file-type (denote-filetype-heuristics file)))
+     (list
+      file
+      (denote-title-prompt
+       (denote--retrieve-title-or-filename file file-type))
+      (denote-keywords-prompt)
+      current-prefix-arg)))
+  (let* ((dir (file-name-directory file))
+         (id (denote-retrieve-or-create-file-identifier file date :unique))
+         (signature (denote-retrieve-filename-signature file))
+         (extension (file-name-extension file t))
+         (file-type (denote-filetype-heuristics file))
+         (new-name (denote-format-file-name
+                    dir id keywords (denote-sluggify title) extension signature))
+         (max-mini-window-height 0.33)) ; allow minibuffer to be resized
+    (when (denote-rename-file-prompt file new-name)
+      (denote-rename-file-and-buffer file new-name)
+      (denote-update-dired-buffers)
+      (when (denote-file-is-writable-and-supported-p new-name)
+        (if (denote--edit-front-matter-p new-name file-type)
+            (denote-rewrite-front-matter new-name title keywords file-type)
+          (denote--add-front-matter new-name title keywords id file-type))))))
+
+;;;###autoload
+(defun denote-change-file-type (file new-file-type)
+  "Change file type of FILE and add an appropriate front matter.
+
+If in Dired, consider FILE to be the one at point, else prompt
+with minibuffer completion for one.
+
+Add a front matter in the format of the NEW-FILE-TYPE at the
+beginning of the file.
+
+Retrieve the title of FILE from a line starting with a title
+field in its front matter, depending on the previous file
+type (e.g.  #+title for Org).  The same process applies for
+keywords.
+
+As a final step, ask for confirmation, showing the difference
+between old and new file names.
+
+Important note: No attempt is made to modify any other elements
+of the file.  This needs to be done manually."
+  (interactive
+   (list
+    (denote--rename-dired-file-or-prompt)
+    (denote--valid-file-type (or (denote-file-type-prompt) denote-file-type))))
+  (let* ((dir (file-name-directory file))
+         (old-file-type (denote-filetype-heuristics file))
+         (id (denote-retrieve-or-create-file-identifier file))
+         (title (denote-retrieve-title-value file old-file-type))
+         (keywords (denote-retrieve-keywords-value file old-file-type))
+         (old-extension (file-name-extension file t))
+         (new-extension (denote--file-extension new-file-type))
+         (new-name (denote-format-file-name
+                    dir id keywords (denote-sluggify title) new-extension))
+         (max-mini-window-height 0.33)) ; allow minibuffer to be resized
+    (when (and (not (eq old-extension new-extension))
+               (denote-rename-file-prompt file new-name))
+      (denote-rename-file-and-buffer file new-name)
+      (denote-update-dired-buffers)
+      (when (denote-file-is-writable-and-supported-p new-name)
+        (denote--add-front-matter new-name title keywords id new-file-type)))))
+
+;;;###autoload
+(defun denote-dired-rename-marked-files (&optional skip-front-matter-prompt no-unique-id-check)
+  "Rename marked files in Dired to a Denote file name.
+
+Specifically, do the following:
+
+- retain the file's existing name and make it the TITLE field,
+  per Denote's file-naming scheme;
+
+- downcase and sluggify the TITLE, per our conventions;
+
+- prepend an identifier to the TITLE;
+
+- preserve the file's extension, if any;
+
+- prompt once for KEYWORDS and apply the user's input to the
+  corresponding field in the file name;
+
+- add or rewrite existing front matter to the underlying file, if
+  it is recognized as a Denote note (per `denote-file-type'),
+  such that it includes the new keywords;
+
+- prompt at the outset for a confirmation, unless optional
+  SKIP-FRONT-MATTER-PROMPT is non-nil (such as with a universal
+  prefix argument).
+
+  [ Note that the affected buffers are not saved.  Users can thus
+    check them to confirm that the new front matter does not
+    cause any problems (e.g. with the `diff-buffer-with-file'
+    command).  Multiple buffers can be saved in one go with
+    `save-some-buffers' (read its doc string). ]
+
+With the optional NO-UNIQUE-ID-CHECK as non-nil (such as as a
+double prefix argument), do not process the file identifiers of
+the marked files for potential duplicates.  The default is to
+check for duplicates and increment them such that they become
+unique.  The reason this optional argument exists is for those
+who want to speed up the process, perhaps because they know ahead
+of time all identifiers will be unique or do not care about them.
+
+[ When renaming files in Dired, it is possible to produce
+  duplicate identifiers.  This can happen when multiple files
+  share the same modification time, which can be casually done
+  with the `touch' command, `git', and others. ]"
+  (interactive
+   (list
+    (when current-prefix-arg
+      (setq skip-front-matter-prompt t
+            no-unique-id-check (when (>= (car current-prefix-arg) 16) t))))
+   dired-mode)
+  (if-let ((marks (dired-get-marked-files)))
+      (let ((keywords (denote-keywords-prompt)))
+        (when (or skip-front-matter-prompt
+                  (yes-or-no-p "Add front matter if necessary (buffers are not saved)?"))
+          (dolist (file marks)
+            (let* ((dir (file-name-directory file))
+                   (id (denote-retrieve-or-create-file-identifier file nil (unless no-unique-id-check marks)))
+                   (signature (denote-retrieve-filename-signature file))
+                   (file-type (denote-filetype-heuristics file))
+                   (title (denote--retrieve-title-or-filename file file-type))
+                   (extension (file-name-extension file t))
+                   (new-name (denote-format-file-name dir id keywords (denote-sluggify title) extension signature)))
+              (denote-rename-file-and-buffer file new-name)
+              (when (denote-file-is-writable-and-supported-p new-name)
+                (if (denote--edit-front-matter-p new-name file-type)
+                    (denote-rewrite-keywords new-name keywords file-type)
+                  (denote--add-front-matter new-name title keywords id file-type)))
+              (unless no-unique-id-check
+                (setq marks (delete file marks))
+                (push new-name marks))))
+          (revert-buffer)))
+    (user-error "No marked files; aborting")))
+
+;;;###autoload
+(defun denote-rename-file-using-front-matter (file &optional auto-confirm)
+  "Rename FILE using its front matter as input.
+When called interactively, FILE is the return value of the
+function `buffer-file-name' which is subsequently inspected for
+the requisite front matter.  It is thus implied that the FILE has
+a file type that is supported by Denote, per `denote-file-type'.
+
+Unless AUTO-CONFIRM is non-nil (such as with a prefix argument),
+ask for confirmation, showing the difference between the old and
+the new file names.
+
+Never modify the identifier of the FILE, if any, even if it is
+edited in the front matter.  Denote considers the file name to be
+the source of truth in this case to avoid potential breakage with
+typos and the like.
+
+Refrain from performing the operation if the buffer has unsaved
+changes.  Inform the user about the need to save their changes
+first.  If AUTO-CONFIRM is non-nil, then save the buffer and
+proceed with the renaming."
+  (interactive (list (buffer-file-name) current-prefix-arg))
+  (when (buffer-modified-p)
+    (if (or auto-confirm
+            (y-or-n-p "Would you like to save the buffer?"))
+        (save-buffer)
+      (user-error "Save buffer before proceeding")))
+  (unless (denote-file-is-writable-and-supported-p file)
+    (user-error "The file is not writable or does not have a supported file extension"))
+  (if-let* ((file-type (denote-filetype-heuristics file))
+            (title (denote-retrieve-title-value file file-type))
+            (extension (file-name-extension file t))
+            (id (denote-retrieve-or-create-file-identifier file))
+            (dir (file-name-directory file))
+            (new-name (denote-format-file-name
+                       ;; The `denote-retrieve-keywords-value' and
+                       ;; `denote-retrieve-filename-signature' are
+                       ;; not inside the `if-let*' because we do not
+                       ;; want to throw an exception if any is nil.
+                       dir id
+                       (or (denote-retrieve-keywords-value file file-type) nil)
+                       (denote-sluggify title) extension
+                       (or (denote-retrieve-filename-signature file) nil))))
+      (when (or auto-confirm
+                (denote-rename-file-prompt file new-name))
+        (denote-rename-file-and-buffer file new-name)
+        (denote-update-dired-buffers))
+    (user-error "No front matter for title and/or keywords")))
+
+;;;###autoload
+(defun denote-dired-rename-marked-files-using-front-matter ()
+  "Rename marked files in Dired using their front matter as input.
+Marked files must count as notes for the purposes of Denote,
+which means that they at least have an identifier in their file
+name and use a supported file type, per `denote-file-type'.
+Files that do not meet this criterion are ignored.
+
+The operation does the following:
+
+- the title in the front matter becomes the TITLE component of
+  the file name, with hyphenation per Denote's file-naming
+  scheme;
+
+- the keywords in the front matter are used for the KEYWORDS
+  component of the file name and are processed accordingly, if
+  needed;
+
+- the identifier remains unchanged in the file name even if it is
+  modified in the front matter (this is done to avoid breakage
+  caused by typos and the like).
+
+NOTE that files must be saved, because Denote reads from the
+underlying file, not a modified buffer (this is done to avoid
+potential mistakes).  The return value of a modified buffer is
+the one prior to the modification, i.e. the one already written
+on disk.
+
+This command is useful for synchronizing multiple file names with
+their respective front matter."
+  (interactive nil dired-mode)
+  (if-let ((marks (seq-filter
+                   #'denote-file-is-writable-and-supported-p
+                   (dired-get-marked-files))))
+      (progn
+        (dolist (file marks)
+          (let* ((dir (file-name-directory file))
+                 (id (denote-retrieve-or-create-file-identifier file))
+                 (signature (denote-retrieve-filename-signature file))
+                 (file-type (denote-filetype-heuristics file))
+                 (title (denote-retrieve-title-value file file-type))
+                 (keywords (denote-retrieve-keywords-value file file-type))
+                 (extension (file-name-extension file t))
+                 (new-name (denote-format-file-name
+                            dir id keywords (denote-sluggify title) extension signature)))
+            (denote-rename-file-and-buffer file new-name)))
+        (revert-buffer))
+    (user-error "No marked files; aborting")))
+
+;;;;; Creation of front matter
+
+;;;###autoload
+(defun denote-add-front-matter (file title keywords)
+  "Insert front matter at the top of FILE.
+
+When called interactively, FILE is the return value of the
+function `buffer-file-name'.  FILE is checked to determine
+whether it is a note for Denote's purposes.
+
+TITLE is a string.  Interactively, it is the user input at the
+minibuffer prompt.
+
+KEYWORDS is a list of strings.  Interactively, it is the user
+input at the minibuffer prompt.  This one supports completion for
+multiple entries, each separated by the `crm-separator' (normally
+a comma).
+
+The purpose of this command is to help the user generate new
+front matter for an existing note (perhaps because the user
+deleted the previous one and could not undo the change).
+
+This command does not rename the file (e.g. to update the
+keywords).  To rename a file by reading its front matter as
+input, use `denote-rename-file-using-front-matter'.
+
+Note that this command is useful only for existing Denote notes.
+If the user needs to convert a generic text file to a Denote
+note, they can use one of the command which first rename the file
+to make it comply with our file-naming scheme and then add the
+relevant front matter."
+  (interactive
+   (list
+    (buffer-file-name)
+    (denote-title-prompt)
+    (denote-keywords-prompt)))
+  (when (denote-file-is-writable-and-supported-p file)
+    (denote--add-front-matter
+     file title keywords
+     (denote-retrieve-or-create-file-identifier file nil)
+     (denote-filetype-heuristics file))))
+
+;;;; The Denote faces
+
+(defgroup denote-faces ()
+  "Faces for Denote."
+  :group 'denote)
+
+(defface denote-faces-link '((t :inherit link))
+  "Face used to style Denote links in the buffer."
+  :group 'denote-faces
+  :package-version '(denote . "0.5.0"))
+
+(make-obsolete-variable 'denote-faces-broken-link nil "1.0.0")
+
+(defface denote-faces-subdirectory '((t :inherit bold))
+  "Face for subdirectory of file name.
+This should only ever needed in the backlinks' buffer (or
+equivalent), not in Dired."
+  :group 'denote-faces
+  :package-version '(denote . "0.2.0"))
+
+(defface denote-faces-date '((t :inherit font-lock-variable-name-face))
+  "Face for file name date in Dired buffers.
+This is the part of the identifier that covers the year, month,
+and day."
+  :group 'denote-faces
+  :package-version '(denote . "0.1.0"))
+
+(defface denote-faces-time '((t :inherit denote-faces-date))
+  "Face for file name time in Dired buffers.
+This is the part of the identifier that covers the hours, minutes,
+and seconds."
+  :group 'denote-faces
+  :package-version '(denote . "0.1.0"))
+
+(defface denote-faces-title nil
+  "Face for file name title in Dired buffers."
+  :group 'denote-faces
+  :package-version '(denote . "0.1.0"))
+
+(defface denote-faces-extension '((t :inherit shadow))
+  "Face for file extension type in Dired buffers."
+  :group 'denote-faces
+  :package-version '(denote . "0.1.0"))
+
+(defface denote-faces-keywords '((t :inherit font-lock-builtin-face))
+  "Face for file name keywords in Dired buffers."
+  :group 'denote-faces
+  :package-version '(denote . "0.1.0"))
+
+(defface denote-faces-signature '((t :inherit font-lock-warning-face))
+  "Face for file name signature in Dired buffers."
+  :group 'denote-faces
+  :package-version '(denote . "2.0.0"))
+
+(defface denote-faces-delimiter
+  '((((class color) (min-colors 88) (background light))
+     :foreground "gray70")
+    (((class color) (min-colors 88) (background dark))
+     :foreground "gray30")
+    (t :inherit shadow))
+  "Face for file name delimiters in Dired buffers."
+  :group 'denote-faces
+  :package-version '(denote . "0.1.0"))
+
+;; For character classes, evaluate: (info "(elisp) Char Classes")
+(defvar denote-faces--file-name-regexp
+  (concat "\\(?1:[0-9]\\{8\\}\\)\\(?2:T[0-9]\\{6\\}\\)"
+          "\\(?:\\(?3:==\\)\\(?4:[[:alnum:][:nonascii:]=]*?\\)\\)?"
+          "\\(?:\\(?5:--\\)\\(?6:[[:alnum:][:nonascii:]-]*?\\)\\)?"
+          "\\(?:\\(?7:__\\)\\(?8:[[:alnum:][:nonascii:]_-]*?\\)\\)?"
+          "\\(?9:\\..*\\)?$")
+  "Regexp of file names for fontification.")
+
+(defconst denote-faces-file-name-keywords
+  `((,(concat "[\t\s]+" denote-faces--file-name-regexp)
+     (1 'denote-faces-date)
+     (2 'denote-faces-time)
+     (3 'denote-faces-delimiter nil t)
+     (4 'denote-faces-signature nil t)
+     (5 'denote-faces-delimiter nil t)
+     (6 'denote-faces-title nil t)
+     (7 'denote-faces-delimiter nil t)
+     (8 'denote-faces-keywords nil t)
+     (9 'denote-faces-extension nil t )))
+  "Keywords for fontification of file names.")
+
+(defconst denote-faces-file-name-keywords-for-backlinks
+  `((,(concat "^\\(?10:.*/\\)?" denote-faces--file-name-regexp)
+     (10 'denote-faces-subdirectory nil t)
+     (1 'denote-faces-date)
+     (2 'denote-faces-time)
+     (3 'denote-faces-delimiter nil t)
+     (4 'denote-faces-signature nil t)
+     (5 'denote-faces-delimiter nil t)
+     (6 'denote-faces-title nil t)
+     (7 'denote-faces-delimiter nil t)
+     (8 'denote-faces-keywords nil t)
+     (9 'denote-faces-extension nil t )))
+  "Keywords for fontification of file names in the backlinks buffer.")
+
+;;;; Fontification in Dired
+
+(defgroup denote-dired ()
+  "Integration between Denote and Dired."
+  :group 'denote)
+
+(defcustom denote-dired-directories (list denote-directory)
+  "List of directories where `denote-dired-mode' should apply to.
+For this to take effect, add `denote-dired-mode-in-directories',
+to the `dired-mode-hook'."
+  :type '(repeat directory)
+  :package-version '(denote . "0.1.0")
+  :link '(info-link "(denote) Fontification in Dired")
+  :group 'denote-dired)
+
+;; NOTE 2022-09-12: I tried to use the `dired-font-lock-keywords', but
+;; then it overrides the standard Dired faces.  The `diredfl' package
+;; uses that method, though it redefines all Dired faces.  We don't want
+;; to do that.
+
+;; FIXME 2022-08-12: Make `denote-dired-mode' actually apply to Dired.
+;; FIXME 2022-08-12: Make `denote-dired-mode' persist after WDired.
+;; FIXME 2022-08-12: Make `denote-dired-mode' work with diredfl.  This
+;; may prove challenging.
+
+;;;###autoload
+(define-minor-mode denote-dired-mode
+  "Fontify all Denote-style file names.
+Add this or `denote-dired-mode-in-directories' to
+`dired-mode-hook'."
+  :global nil
+  :group 'denote-dired
+  (if denote-dired-mode
+      (font-lock-add-keywords nil denote-faces-file-name-keywords t)
+    (font-lock-remove-keywords nil denote-faces-file-name-keywords))
+  (font-lock-flush (point-min) (point-max)))
+
+(defun denote-dired--modes-dirs-as-dirs ()
+  "Return `denote-dired-directories' as directories.
+The intent is to basically make sure that however a path is
+written, it is always returned as a directory."
+  (mapcar
+   (lambda (dir)
+     (file-name-as-directory (file-truename dir)))
+   denote-dired-directories))
+
+;;;###autoload
+(defun denote-dired-mode-in-directories ()
+  "Enable `denote-dired-mode' in `denote-dired-directories'.
+Add this function to `dired-mode-hook'."
+  (when (member (file-truename default-directory) (denote-dired--modes-dirs-as-dirs))
+    (denote-dired-mode 1)))
+
+;;;; The linking facility
+
+(defgroup denote-link ()
+  "Link facility for Denote."
+  :group 'denote)
+
+;;;;; User options
+
+(defcustom denote-link-backlinks-display-buffer-action
+  '((display-buffer-reuse-window display-buffer-below-selected)
+    (window-height . fit-window-to-buffer))
+  "The action used to display the current file's backlinks buffer.
+
+The value has the form (FUNCTION . ALIST), where FUNCTION is
+either an \"action function\", a list thereof, or possibly an
+empty list.  ALIST is a list of \"action alist\" which may be
+omitted (or be empty).
+
+Sample configuration to display the buffer in a side window on
+the left of the Emacs frame:
+
+    (setq denote-link-backlinks-display-buffer-action
+          (quote ((display-buffer-reuse-window
+                   display-buffer-in-side-window)
+                  (side . left)
+                  (slot . 99)
+                  (window-width . 0.3))))
+
+See Info node `(elisp) Displaying Buffers' for more details
+and/or the documentation string of `display-buffer'."
+  :type '(cons (choice (function :tag "Display Function")
+                       (repeat :tag "Display Functions" function))
+               alist)
+  :package-version '(denote . "0.1.0")
+  :group 'denote-link)
+
+;;;;; Link to note
+
+(define-obsolete-variable-alias
+  'denote-link--format-org
+  'denote-org-link-format
+  "1.2.0")
+
+(defvar denote-org-link-format "[[denote:%s][%s]]"
+  "Format of Org link to note.
+The value is passed to `format' with IDENTIFIER and TITLE
+arguments, in this order.
+
+Also see `denote-org-link-in-context-regexp'.")
+
+(define-obsolete-variable-alias
+  'denote-link--format-markdown
+  'denote-md-link-format
+  "1.2.0")
+
+(defvar denote-md-link-format "[%2$s](denote:%1$s)"
+  "Format of Markdown link to note.
+The %N$s notation used in the default value is for `format' as
+the supplied arguments are IDENTIFIER and TITLE, in this order.
+
+Also see `denote-md-link-in-context-regexp'.")
+
+(define-obsolete-variable-alias
+  'denote-link--format-id-only
+  'denote-id-only-link-format
+  "1.2.0")
+
+(defvar denote-id-only-link-format "[[denote:%s]]"
+  "Format of identifier-only link to note.
+The value is passed to `format' with IDENTIFIER as its sole
+argument.
+
+Also see `denote-id-only-link-in-context-regexp'.")
+
+(define-obsolete-variable-alias
+  'denote-link--regexp-org
+  'denote-org-link-in-context-regexp
+  "1.2.0")
+
+(defvar denote-org-link-in-context-regexp
+  (concat "\\[\\[" "denote:"  "\\(?1:" denote-id-regexp "\\)" "]" "\\[.*?]]")
+  "Regexp to match an Org link in its context.
+The format of such links is `denote-org-link-format'.")
+
+(define-obsolete-variable-alias
+  'denote-link--regexp-markdown
+  'denote-md-link-in-context-regexp
+  "1.2.0")
+
+(defvar denote-md-link-in-context-regexp
+  (concat "\\[.*?]" "(denote:"  "\\(?1:" denote-id-regexp "\\)" ")")
+  "Regexp to match a Markdown link in its context.
+The format of such links is `denote-md-link-format'.")
+
+(define-obsolete-variable-alias
+  'denote-link--regexp-plain
+  'denote-id-only-link-in-context-regexp
+  "1.2.0")
+
+(defvar denote-id-only-link-in-context-regexp
+  (concat "\\[\\[" "denote:"  "\\(?1:" denote-id-regexp "\\)" "]]")
+  "Regexp to match an identifier-only link in its context.
+The format of such links is `denote-id-only-link-format'."  )
+
+(defun denote-link--file-type-format (file-type id-only)
+  "Return link format based on FILE-TYPE.
+With non-nil ID-ONLY, use the generic link format without a
+title.
+
+Fall back to `denote-org-link-format'."
+  ;; Includes backup files.  Maybe we can remove them?
+  (cond
+   (id-only denote-id-only-link-format)
+   ((when-let ((link (denote--link-format file-type)))
+      link))
+   ;; Plain text also uses [[denote:ID][TITLE]]
+   (t denote-org-link-format)))
+
+(defun denote-link--format-link (file format &optional description)
+  "Prepare link to FILE using FORMAT.
+If DESCRIPTION is non-nil, use it as link description instead of
+FILE's title.
+
+FORMAT is the symbol of a variable that specifies a string.  See
+the `:link' property of `denote-file-types'."
+  (let* ((file-id (denote-retrieve-filename-identifier file))
+         (fm (if (symbolp format) (symbol-value format) format))
+         (file-type (denote-filetype-heuristics file))
+         (file-title (unless (string= fm denote-id-only-link-format)
+                       (or description (denote--retrieve-title-or-filename file file-type)))))
+    (format fm file-id file-title)))
+
+;;;###autoload
+(defun denote-link (target &optional id-only)
+  "Create link to TARGET note in variable `denote-directory'.
+With optional ID-ONLY, such as a universal prefix
+argument (\\[universal-argument]), insert links with just the
+identifier and no further description.  In this case, the link
+format is always [[denote:IDENTIFIER]].
+
+Use TARGET's title for the link's description.  The title comes
+either from the front matter or the file name.
+
+If region is active, use its text as the link's description
+instead of TARGET's title.  If active region is empty (i.e
+whitespace-only), insert an ID-ONLY link."
+  (interactive (list (denote-file-prompt) current-prefix-arg))
+  (let* ((beg (point))
+         (description (when-let* (((region-active-p))
+                                  (beg (region-beginning))
+                                  (end (region-end))
+                                  (selected-text
+                                   (string-trim
+                                    (buffer-substring-no-properties beg end))))
+                        (delete-region beg end)
+                        selected-text))
+         (identifier-only (or id-only (string-empty-p description)))
+         (file-type (denote-filetype-heuristics (buffer-file-name))))
+    (when target
+      (insert
+       (denote-link--format-link
+        target
+        (denote-link--file-type-format file-type identifier-only)
+        description))
+      (unless (derived-mode-p 'org-mode)
+        (make-button beg (point) 'type 'denote-link-button)))))
+
+(define-obsolete-function-alias
+  'denote-link-insert-link
+  'denote-insert-link
+  "2.0.0")
+
+(defalias 'denote-insert-link 'denote-link
+  "Alias for `denote-link' command.")
+
+(defun denote-link--collect-identifiers (regexp)
+  "Return collection of identifiers in buffer matching REGEXP."
+  (let (matches)
+    (save-excursion
+      (goto-char (point-min))
+      (while (or (re-search-forward regexp nil t)
+                 (re-search-forward denote-id-only-link-in-context-regexp nil t))
+        (push (match-string-no-properties 1) matches)))
+    matches))
+
+(defun denote-link--expand-identifiers (regexp)
+  "Expend identifiers matching REGEXP into file paths."
+  (let ((files (denote-directory-files))
+        (rx (if (symbolp regexp) (symbol-value regexp) regexp))
+        found-files)
+    (dolist (file files)
+      (dolist (i (denote-link--collect-identifiers rx))
+        (when (string-prefix-p i (file-name-nondirectory file))
+          (push file found-files))))
+    found-files))
+
+(defvar denote-link--find-file-history nil
+  "History for `denote-find-link'.")
+
+(defun denote-link--find-file-prompt (files)
+  "Prompt for linked file among FILES."
+  (let ((file-names (mapcar #'denote-get-file-name-relative-to-denote-directory
+                            files)))
+    (completing-read
+     "Find linked file: "
+     (denote--completion-table 'file file-names)
+     nil t nil 'denote-link--find-file-history)))
+
+(defun denote-link-return-links (&optional file)
+  "Return list of links in current or optional FILE.
+Also see `denote-link-return-backlinks'."
+  (when-let* ((current-file (or file (buffer-file-name)))
+              ((denote-file-has-supported-extension-p current-file))
+              (file-type (denote-filetype-heuristics current-file))
+              (regexp (denote--link-in-context-regexp file-type))
+              (links (with-current-buffer (find-file-noselect current-file)
+                       (denote-link--expand-identifiers regexp))))
+    links))
+
+(defalias 'denote-link-return-forelinks 'denote-link-return-links
+  "Alias for `denote-link-return-links'.")
+
+(define-obsolete-function-alias
+  'denote-link-find-file
+  'denote-find-link
+  "2.0.0")
+
+;;;###autoload
+(defun denote-find-link ()
+  "Use minibuffer completion to visit linked file."
+  (interactive)
+  (find-file
+   (denote-link--find-file-prompt
+    (or (denote-link-return-links)
+        (user-error "No links found")))))
+
+(defun denote-link-return-backlinks (&optional file)
+  "Return list of backlinks in current or optional FILE.
+Also see `denote-link-return-links'."
+  (when-let* ((current-file (or file (buffer-file-name)))
+              (id (denote-retrieve-filename-identifier current-file))
+              (backlinks (delete current-file (denote--retrieve-files-in-xrefs id))))
+    backlinks))
+
+(define-obsolete-function-alias
+  'denote-link-find-backlink
+  'denote-find-backlink
+  "2.0.0")
+
+;;;###autoload
+(defun denote-find-backlink ()
+  "Use minibuffer completion to visit backlink to current file.
+
+Like `denote-find-link', but select backlink to follow."
+  (interactive)
+  (find-file
+   (denote-get-path-by-id
+    (denote-extract-id-from-string
+     (denote-link--find-file-prompt
+      (or (denote-link-return-backlinks)
+          (user-error "No backlinks found")))))))
+
+;;;###autoload
+(defun denote-link-after-creating (&optional id-only)
+  "Create new note in the background and link to it directly.
+
+Use `denote' interactively to produce the new note.  Its doc
+string explains which prompts will be used and under what
+conditions.
+
+With optional ID-ONLY as a prefix argument create a link that
+consists of just the identifier.  Else try to also include the
+file's title.  This has the same meaning as in `denote-link'.
+
+IMPORTANT NOTE: Normally, `denote' does not save the buffer it
+produces for the new note.  This is a safety precaution to not
+write to disk unless the user wants it (e.g. the user may choose
+to kill the buffer, thus cancelling the creation of the note).
+However, for this command the creation of the note happens in the
+background and the user may miss the step of saving their buffer.
+We thus have to save the buffer in order to (i) establish valid
+links, and (ii) retrieve whatever front matter from the target
+file."
+  (interactive "P")
+  (let (path)
+    (save-window-excursion
+      (call-interactively #'denote)
+      (save-buffer)
+      (setq path (buffer-file-name)))
+    (denote-link path id-only)))
+
+;;;###autoload
+(defun denote-link-or-create (target &optional id-only)
+  "Use `denote-link' on TARGET file, creating it if necessary.
+
+If TARGET file does not exist, call `denote-link-after-creating'
+which runs the `denote' command interactively to create the file.
+The established link will then be targeting that new file.
+
+If TARGET file does not exist, add the user input that was used
+to search for it to the minibuffer history of the
+`denote-file-prompt'.  The user can then retrieve and possibly
+further edit their last input, using it as the newly created
+note's actual title.  At the `denote-file-prompt' type
+\\<minibuffer-local-map>\\[previous-history-element].
+
+With optional ID-ONLY as a prefix argument create a link that
+consists of just the identifier.  Else try to also include the
+file's title.  This has the same meaning as in `denote-link'."
+  (interactive (list (denote-file-prompt) current-prefix-arg))
+  (if (and target (file-exists-p target))
+      (denote-link target id-only)
+    (denote--command-with-title-history #'denote-link-after-creating)))
+
+(defalias 'denote-link-to-existing-or-new-note 'denote-link-or-create
+  "Alias for `denote-link-or-create' command.")
+
+;;;;; Link buttons
+
+;; Evaluate: (info "(elisp) Button Properties")
+;;
+;; Button can provide a help-echo function as well, but I think we might
+;; not need it.
+(define-button-type 'denote-link-button
+  'follow-link t
+  'face 'denote-faces-link
+  'action #'denote-link--find-file-at-button)
+
+(autoload 'thing-at-point-looking-at "thingatpt")
+
+(defun denote-link--link-at-point-string ()
+  "Return identifier at point."
+  (when (or (thing-at-point-looking-at denote-id-only-link-in-context-regexp)
+            (thing-at-point-looking-at denote-md-link-in-context-regexp)
+            (thing-at-point-looking-at denote-org-link-in-context-regexp)
+            ;; Meant to handle the case where a link is broken by
+            ;; `fill-paragraph' into two lines, in which case it
+            ;; buttonizes only the "denote:ID" part.  Example:
+            ;;
+            ;; [[denote:20220619T175212][This is a
+            ;; test]]
+            ;;
+            ;; Maybe there is a better way?
+            (thing-at-point-looking-at "\\[\\(denote:.*\\)]"))
+    (match-string-no-properties 0)))
+
+;; NOTE 2022-06-15: I add this as a variable for advanced users who may
+;; prefer something else.  If there is demand for it, we can make it a
+;; defcustom, but I think it would be premature at this stage.
+(defvar denote-link-button-action #'find-file-other-window
+  "Display buffer action for Denote buttons.")
+
+(defun denote-link--find-file-at-button (button)
+  "Visit file referenced by BUTTON."
+  (let* ((id (denote-extract-id-from-string
+              (buffer-substring-no-properties
+               (button-start button)
+               (button-end button))))
+         (file (denote-get-path-by-id id)))
+    (funcall denote-link-button-action file)))
+
+;;;###autoload
+(defun denote-link-buttonize-buffer (&optional beg end)
+  "Make denote: links actionable buttons in the current buffer.
+
+Buttonization applies to the plain text and Markdown file types,
+per the user option `denote-file-types'.  It will not do anything
+in `org-mode' buffers, as buttons already work there.  If you do
+not use Markdown or plain text, then you do not need this.
+
+Links work when they point to a file inside the variable
+`denote-directory'.
+
+To buttonize links automatically add this function to the
+`find-file-hook'.  Or call it interactively for on-demand
+buttonization.
+
+When called from Lisp, with optional BEG and END as buffer
+positions, limit the process to the region in-between."
+  (interactive)
+  (when (and (not (derived-mode-p 'org-mode))
+             (denote-file-has-identifier-p (buffer-file-name)))
+    (save-excursion
+      (goto-char (or beg (point-min)))
+      (while (re-search-forward denote-id-regexp end t)
+        (when-let ((string (denote-link--link-at-point-string))
+                   (beg (match-beginning 0))
+                   (end (match-end 0)))
+          (make-button beg end 'type 'denote-link-button))))))
+
+;;;;; Backlinks' buffer
+
+(define-button-type 'denote-link-backlink-button
+  'follow-link t
+  'action #'denote-link--backlink-find-file
+  'face nil)            ; we use this face though we style it later
+
+(defun denote-link--backlink-find-file (button)
+  "Action for BUTTON to `find-file'."
+  (funcall denote-link-button-action (buffer-substring (button-start button) (button-end button))))
+
+(defun denote-link--display-buffer (buf)
+  "Run `display-buffer' on BUF.
+Expand `denote-link-backlinks-display-buffer-action'."
+  (display-buffer
+   buf
+   `(,@denote-link-backlinks-display-buffer-action)))
+
+(defun denote-backlinks-next (&optional n)
+  "Use appropriate command for forward motion in backlinks buffer.
+With optional N as a numeric argument, move to the Nth button
+from point (relevant when `denote-backlinks-show-context' is
+nil)."
+  (interactive "p" denote-backlinks-mode)
+  (if denote-backlinks-show-context
+      (xref-next-line)
+    (forward-button n)))
+
+(defun denote-backlinks-prev (&optional n)
+  "Use appropriate command for backward motion in backlinks buffer.
+With optional N as a numeric argument, move to the Nth button
+from point (relevant when `denote-backlinks-show-context' is
+nil)."
+  (interactive "p" denote-backlinks-mode)
+  (if denote-backlinks-show-context
+      (xref-prev-line)
+    (backward-button n)))
+
+(defvar denote-backlinks-mode-map
+  (let ((m (make-sparse-keymap)))
+    (define-key m "n" #'denote-backlinks-next)
+    (define-key m "p" #'denote-backlinks-prev)
+    (define-key m "g" #'revert-buffer)
+    m)
+  "Keymap for `denote-backlinks-mode'.")
+
+(make-obsolete-variable 'denote-backlink-mode-map 'denote-backlinks-mode-map "0.6.0")
+
+(define-derived-mode denote-backlinks-mode xref--xref-buffer-mode "Backlinks"
+  "Major mode for backlinks buffers."
+  (unless denote-backlinks-show-context
+    (font-lock-add-keywords nil denote-faces-file-name-keywords-for-backlinks t))
+  (add-hook 'project-find-functions #'denote-project-find nil t))
+
+(make-obsolete-variable 'denote-backlink-mode 'denote-backlinks-mode "0.6.0")
+
+(defun denote-link--prepare-backlinks (fetcher _alist)
+  "Create backlinks' buffer for the current note.
+FETCHER is a function that fetches a list of xrefs.  It is called
+with `funcall' with no argument like `xref--fetcher'.
+
+In the case of `denote', `apply-partially' is used to create a
+function that has already applied another function to multiple
+arguments.
+
+ALIST is not used in favour of using
+`denote-link-backlinks-display-buffer-action'."
+  (let* ((inhibit-read-only t)
+         (file (buffer-file-name))
+         (file-type (denote-filetype-heuristics file))
+         (id (denote-retrieve-filename-identifier file))
+         (buf (format "*denote-backlinks to %s*" id))
+         (xref-alist (xref--analyze (funcall fetcher)))
+         (dir (denote-directory)))
+    (with-current-buffer (get-buffer-create buf)
+      (setq-local default-directory dir)
+      (erase-buffer)
+      (setq overlay-arrow-position nil)
+      (denote-backlinks-mode)
+      (goto-char (point-min))
+      (when-let*  ((title (denote-retrieve-title-value file file-type))
+                   (heading (format "Backlinks to %S (%s)" title id))
+                   (l (length heading)))
+        (insert (format "%s\n%s\n\n" heading (make-string l ?-))))
+      (if denote-backlinks-show-context
+          (xref--insert-xrefs xref-alist)
+        (mapc (lambda (x)
+                (insert (car x))
+                (make-button (line-beginning-position) (line-end-position) :type 'denote-link-backlink-button)
+                (newline))
+              xref-alist))
+      (goto-char (point-min))
+      (setq-local revert-buffer-function
+                  (lambda (_ignore-auto _noconfirm)
+                    (when-let ((buffer-file-name file))
+                      (denote-link--prepare-backlinks
+                       (apply-partially #'xref-matches-in-files id
+                                        (delete file (denote-directory-text-only-files)))
+                       nil)))))
+    (denote-link--display-buffer buf)))
+
+(define-obsolete-function-alias
+  'denote-link-backlinks
+  'denote-backlinks
+  "2.0.0")
+
+;;;###autoload
+(defun denote-backlinks ()
+  "Produce a buffer with backlinks to the current note.
+
+The backlinks' buffer shows the file name of the note linking to
+the current note, as well as the context of each link.
+
+File names are fontified by Denote if the user option
+`denote-link-fontify-backlinks' is non-nil.  If this user option
+is nil, the buffer is fontified by Xref.
+
+The placement of the backlinks' buffer is controlled by the user
+option `denote-link-backlinks-display-buffer-action'.  By
+default, it will show up below the current window."
+  (interactive)
+  (let ((file (buffer-file-name)))
+    (when (denote-file-is-writable-and-supported-p file)
+      (let* ((id (denote-retrieve-filename-identifier file))
+             (xref-show-xrefs-function #'denote-link--prepare-backlinks)
+             (project-find-functions #'denote-project-find))
+        (xref--show-xrefs
+         (apply-partially #'xref-matches-in-files id
+                          ;; remove the current buffer file from the
+                          ;; backlinks
+                          (delete file (denote-directory-text-only-files)))
+         nil)))))
+
+(define-obsolete-function-alias
+  'denote-link-show-backlinks-buffer
+  'denote-show-backlinks-buffer
+  "2.0.0")
+
+(defalias 'denote-show-backlinks-buffer 'denote-backlinks
+  "Alias for `denote-backlinks' command.")
+
+;;;;; Add links matching regexp
+
+(defvar denote-link--prepare-links-format "- %s\n"
+  "Format specifiers for `denote-link-add-links'.")
+
+;; NOTE 2022-06-16: There is no need to overwhelm the user with options,
+;; though I expect someone to want to change the sort order.
+(defvar denote-link-add-links-sort nil
+  "When t, add REVERSE to `sort-lines' of `denote-link-add-links'.")
+
+(defun denote-link--prepare-links (files current-file id-only)
+  "Prepare links to FILES from CURRENT-FILE.
+When ID-ONLY is non-nil, use a generic link format.  See
+`denote-link--file-type-format'."
+  (with-temp-buffer
+    (mapc (lambda (file)
+            (insert
+             (format
+              denote-link--prepare-links-format
+              (denote-link--format-link
+               file
+               (denote-link--file-type-format current-file id-only)))))
+          files)
+    (sort-lines denote-link-add-links-sort (point-min) (point-max))
+    (buffer-string)))
+
+(defvar denote-link--add-links-history nil
+  "Minibuffer history for `denote-add-links'.")
+
+(define-obsolete-function-alias
+  'denote-link-add-links
+  'denote-add-links
+  "2.0.0")
+
+;;;###autoload
+(defun denote-add-links (regexp &optional id-only)
+  "Insert links to all notes matching REGEXP.
+Use this command to reference multiple files at once.
+Particularly useful for the creation of metanotes (read the
+manual for more on the matter).
+
+Optional ID-ONLY has the same meaning as in `denote-link': it
+inserts links with just the identifier."
+  (interactive
+   (list
+    (read-regexp "Insert links matching REGEX: " nil 'denote-link--add-links-history)
+    current-prefix-arg))
+  (let* ((current-file (buffer-file-name))
+         (file-type (denote-filetype-heuristics current-file)))
+    (if-let ((files (delete current-file
+                            (denote-directory-files-matching-regexp regexp)))
+             (beg (point)))
+        (progn
+          (insert (denote-link--prepare-links files file-type id-only))
+          (denote-link-buttonize-buffer beg (point)))
+      (message "No links matching `%s'" regexp))))
+
+(defalias 'denote-link-insert-links-matching-regexp 'denote-add-links
+  "Alias for `denote-add-links' command.")
+
+(define-obsolete-function-alias
+  'denote-link-add-missing-links
+  'denote-add-missing-links
+  "2.0.0")
+
+;;;###autoload
+(defun denote-add-missing-links (regexp &optional id-only)
+  "Insert missing links to all notes matching REGEXP.
+Similar to `denote-add-links' but insert only links not yet
+present in the current buffer.
+
+Optional ID-ONLY has the same meaning as in `denote-link': it
+inserts links with just the identifier."
+  (interactive
+   (list
+    (read-regexp "Insert links matching REGEX: " nil 'denote-link--add-links-history)
+    current-prefix-arg))
+  (let* ((current-file (buffer-file-name))
+         (file-type (denote-filetype-heuristics current-file))
+         (current-id (denote--link-in-context-regexp file-type))
+         (linked-files (denote-link--expand-identifiers current-id)))
+    (if-let* ((found-files (delete current-file
+                                   (denote-directory-files-matching-regexp regexp)))
+              (final-files (seq-difference found-files linked-files))
+              (beg (point)))
+        (progn
+          (insert (denote-link--prepare-links final-files file-type id-only))
+          (denote-link-buttonize-buffer beg (point)))
+      (message "No links matching `%s' that aren't yet present in the current buffer" regexp))))
+
+;;;;; Links from Dired marks
+
+;; NOTE 2022-07-21: I don't think we need a history for this one.
+(defun denote-link--buffer-prompt (buffers)
+  "Select buffer from BUFFERS visiting Denote notes."
+  (let ((buffer-file-names (mapcar #'file-name-nondirectory
+                                   buffers)))
+    (completing-read
+     "Select note buffer: "
+     (denote--completion-table 'buffer buffer-file-names)
+     nil t)))
+
+(defun denote-link--map-over-notes ()
+  "Return list of `denote-file-is-note-p' from Dired marked items."
+  (seq-filter
+   (lambda (f)
+     (and (denote-file-is-note-p f)
+          (denote--dir-in-denote-directory-p default-directory)))
+   (dired-get-marked-files)))
+
+;;;###autoload
+(defun denote-link-dired-marked-notes (files buffer &optional id-only)
+  "Insert Dired marked FILES as links in BUFFER.
+
+FILES are Denote notes, meaning that they have our file-naming
+scheme, are writable/regular files, and use the appropriate file
+type extension (per `denote-file-type').  Furthermore, the marked
+files need to be inside the variable `denote-directory' or one of
+its subdirectories.  No other file is recognised (the list of
+marked files ignores whatever does not count as a note for our
+purposes).
+
+The BUFFER is one which visits a Denote note file.  If there are
+multiple buffers, prompt with completion for one among them.  If
+there isn't one, throw an error.
+
+With optional ID-ONLY as a prefix argument, insert links with
+just the identifier (same principle as with `denote-link').
+
+This command is meant to be used from a Dired buffer."
+  (interactive
+   (list
+    (denote-link--map-over-notes)
+    (let ((file-names (denote--buffer-file-names)))
+      (find-file
+       (cond
+        ((null file-names)
+         (user-error "No buffers visiting Denote notes"))
+        ((eq (length file-names) 1)
+         (car file-names))
+        (t
+         (denote-link--buffer-prompt file-names)))))
+    current-prefix-arg)
+   dired-mode)
+  (if (null files)
+      (user-error "No note files to link to")
+    (when (y-or-n-p (format "Create links at point in %s?" buffer))
+      (with-current-buffer buffer
+        (insert (denote-link--prepare-links
+                 files
+                 (denote-filetype-heuristics (buffer-file-name))
+                 id-only))
+        (denote-link-buttonize-buffer)))))
+
+;;;;; Define menu
+
+(defvar denote--menu-contents
+  '("Denote"
+    ["Create a note" denote
+     :help "Create a new note in the `denote-directory'"]
+    ["Create a note with given file type" denote-type
+     :help "Create a new note with a given file type in the `denote-directory'"]
+    ["Create a note in subdirectory" denote-subdirectory
+     :help "Create a new note in a subdirectory of the `denote-directory'"]
+    ["Create a note with date" denote-date
+     :help "Create a new note with a given date in the `denote-directory'"]
+    ["Create a note with signature" denote-signature
+     :help "Create a new note with a given signature in the `denote-directory'"]
+    "---"
+    ["Rename a file" denote-rename-file
+     :help "Rename file interactively"
+     :enable (derived-mode-p 'dired-mode 'text-mode)]
+    ["Rename this file using its front matter" denote-rename-file-using-front-matter
+     :help "Rename the current file using its front matter as input"
+     :enable (derived-mode-p 'text-mode)]
+    ["Rename Dired marked files" denote-dired-rename-marked-files
+     :help "Rename marked files in Dired"
+     :enable (derived-mode-p 'dired-mode)]
+    ["Rename Dired marked files using their front matter" denote-dired-rename-marked-files-using-front-matter
+     :help "Rename marked files in Dired using their front matter as input"
+     :enable (derived-mode-p 'dired-mode)]
+    "---"
+    ["Insert a link" denote-link
+     :help "Insert link to a file in the `denote-directory'"
+     :enable (derived-mode-p 'text-mode)]
+    ["Insert links with regexp" denote-add-links
+     :help "Insert links to files matching regexp in the `denote-directory'"
+     :enable (derived-mode-p 'text-mode)]
+    ["Insert Dired marked files as links" denote-link-dired-marked-notes
+     :help "Rename marked files in Dired as links in a Denote buffer"
+     :enable (derived-mode-p 'dired-mode)]
+    ["Show file backlinks" denote-backlinks
+     :help "Insert link to a file in the `denote-directory'"
+     :enable (derived-mode-p 'text-mode)]
+    "---"
+    ["Highlight Dired file names" denote-dired-mode
+     :help "Apply colors to Denote file name components in Dired"
+     :enable (derived-mode-p 'dired-mode)
+     :style toggle
+     :selected (bound-and-true-p denote-dired-mode)])
+  "Contents of the Denote menu.")
+
+(easy-menu-define denote-global-menu global-map
+  "Menu with all Denote commands, each available in the right context."
+  denote--menu-contents)
+
+(defun denote-context-menu (menu _click)
+  "Populate MENU with Denote commands at CLICK."
+  (define-key menu [denote-separator] menu-bar-separator)
+  (let ((easy-menu (make-sparse-keymap "Denote")))
+    (easy-menu-define nil easy-menu nil
+      denote--menu-contents)
+    (dolist (item (reverse (lookup-key easy-menu [menu-bar])))
+      (when (consp item)
+        (define-key menu (vector (car item)) (cdr item)))))
+  menu)
+
+;;;;; Register `denote:' custom Org hyperlink
+
+(declare-function org-link-open-as-file "ol" (path arg))
+
+(defun denote-link--ol-resolve-link-to-target (link &optional path-id)
+  "Resolve LINK into the appropriate target.
+With optional PATH-ID return a cons cell consisting of the path
+and the identifier."
+  (let* ((search (and (string-match "::\\(.*\\)\\'" link)
+                      (match-string 1 link)))
+         (id (if (and (stringp search) (not (string-empty-p search)))
+                 (substring link 0 (match-beginning 0))
+               link))
+         (path (denote-get-path-by-id id)))
+    (cond
+     (path-id
+      (cons (format "%s" path) (format "%s" id)))
+     ((and (stringp search) (not (string-empty-p search)))
+      (concat path "::" search))
+     (path))))
+
+;;;###autoload
+(defun denote-link-ol-follow (link)
+  "Find file of type `denote:' matching LINK.
+LINK is the identifier of the note, optionally followed by a
+search option akin to that of standard Org `file:' link types.
+Read Info node `(org) Search Options'.
+
+Uses the function `denote-directory' to establish the path to the
+file."
+  (org-link-open-as-file
+   (denote-link--ol-resolve-link-to-target link)
+   nil))
+
+;;;###autoload
+(defun denote-link-ol-complete ()
+  "Like `denote-link' but for Org integration.
+This lets the user complete a link through the `org-insert-link'
+interface by first selecting the `denote:' hyperlink type."
+  (if-let ((file (denote-file-prompt)))
+      (concat "denote:" (denote-retrieve-filename-identifier file))
+    (user-error "No files in `denote-directory'")))
+
+(declare-function org-link-store-props "ol.el" (&rest plist))
+(defvar org-store-link-plist)
+
+;;;###autoload
+(defun denote-link-ol-store ()
+  "Handler for `org-store-link' adding support for denote: links."
+  (when-let* ((file (buffer-file-name))
+              ((denote-file-is-note-p file))
+              (file-type (denote-filetype-heuristics file))
+              (file-id (denote-retrieve-filename-identifier file))
+              (file-title (denote--retrieve-title-or-filename file file-type)))
+    (org-link-store-props
+     :type "denote"
+     :description file-title
+     :link (concat "denote:" file-id))
+    org-store-link-plist))
+
+;;;###autoload
+(defun denote-link-ol-export (link description format)
+  "Export a `denote:' link from Org files.
+The LINK, DESCRIPTION, and FORMAT are handled by the export
+backend."
+  (let* ((path-id (denote-link--ol-resolve-link-to-target link :path-id))
+         (path (file-relative-name (car path-id)))
+         (p (file-name-sans-extension path))
+         (id (cdr path-id))
+         (desc (or description (concat "denote:" id))))
+    (cond
+     ((eq format 'html) (format "<a href=\"%s.html\">%s</a>" p desc))
+     ((eq format 'latex) (format "\\href{%s}{%s}" (replace-regexp-in-string "[\\{}$%&_#~^]" "\\\\\\&" path) desc))
+     ((eq format 'texinfo) (format "@uref{%s,%s}" path desc))
+     ((eq format 'ascii) (format "[%s] <denote:%s>" desc path)) ; NOTE 2022-06-16: May be tweaked further
+     ((eq format 'md) (format "[%s](%s.md)" desc p))
+     (t path))))
+
+;; The `eval-after-load' part with the quoted lambda is adapted from
+;; Elfeed: <https://github.com/skeeto/elfeed/>.
+
+;;;###autoload
+(eval-after-load 'org
+  `(funcall
+    ;; The extra quote below is necessary because uncompiled closures
+    ;; do not evaluate to themselves. The quote is harmless for
+    ;; byte-compiled function objects.
+    ',(lambda ()
+        (with-no-warnings
+          (org-link-set-parameters
+           "denote"
+           :follow #'denote-link-ol-follow
+           :face 'denote-faces-link
+           :complete #'denote-link-ol-complete
+           :store #'denote-link-ol-store
+           :export #'denote-link-ol-export)))))
+
+;;;; Glue code for org-capture
+
+(defgroup denote-org-capture ()
+  "Integration between Denote and Org Capture."
+  :group 'denote)
+
+(defcustom denote-org-capture-specifiers "%l\n%i\n%?"
+  "String with format specifiers for `org-capture-templates'.
+Check that variable's documentation for the details.
+
+The string can include arbitrary text.  It is appended to new
+notes via the `denote-org-capture' function.  Every new note has
+the standard front matter we define."
+  :type 'string
+  :package-version '(denote . "0.1.0")
+  :group 'denote-org-capture)
+
+(defvar denote-last-path nil "Store last path.")
+
+;;;###autoload
+(defun denote-org-capture ()
+  "Create new note through `org-capture-templates'.
+Use this as a function that returns the path to the new file.
+The file is populated with Denote's front matter.  It can then be
+expanded with the usual specifiers or strings that
+`org-capture-templates' supports.
+
+Note that this function ignores the `denote-file-type': it always
+sets the Org file extension for the created note to ensure that
+the capture process works as intended, especially for the desired
+output of the `denote-org-capture-specifiers' (which can include
+arbitrary text).
+
+Consult the manual for template samples."
+  (let* ((title (denote-title-prompt))
+         (keywords (denote-keywords-prompt))
+         (front-matter (denote--format-front-matter
+                        title (denote--date nil 'org) keywords
+                        (format-time-string denote-id-format nil) 'org)))
+    (setq denote-last-path
+          (denote--path title keywords
+                        (file-name-as-directory (denote-directory))
+                        (format-time-string denote-id-format) 'org))
+    (denote--keywords-add-to-history keywords)
+    (concat front-matter denote-org-capture-specifiers)))
+
+;;;###autoload
+(defun denote-org-capture-with-prompts (&optional title keywords subdirectory date template)
+  "Like `denote-org-capture' but with optional prompt parameters.
+
+When called without arguments, do not prompt for anything.  Just
+return the front matter with title and keyword fields empty and
+the date and identifier fields specified.  Also make the file
+name consist of only the identifier plus the Org file name
+extension.
+
+Otherwise produce a minibuffer prompt for every non-nil value
+that corresponds to the TITLE, KEYWORDS, SUBDIRECTORY, DATE, and
+TEMPLATE arguments.  The prompts are those used by the standard
+`denote' command and all of its utility commands.
+
+When returning the contents that fill in the Org capture
+template, the sequence is as follows: front matter, TEMPLATE, and
+then the value of the user option `denote-org-capture-specifiers'.
+
+Important note: in the case of SUBDIRECTORY actual subdirectories
+must exist---Denote does not create them.  Same principle for
+TEMPLATE as templates must exist and are specified in the user
+option `denote-templates'."
+  (let* ((title (if title (denote-title-prompt) ""))
+         (kws (if keywords (denote-keywords-prompt) nil))
+         (directory (file-name-as-directory (if subdirectory (denote-subdirectory-prompt) (denote-directory))))
+         (date (if date (denote--valid-date (denote-date-prompt)) (current-time)))
+         (id (format-time-string denote-id-format date))
+         (template (if template (denote-template-prompt) ""))
+         (front-matter (denote--format-front-matter
+                        title (denote--date date 'org) kws
+                        (format-time-string denote-id-format date) 'org)))
+    (denote-barf-duplicate-id id)
+    (setq denote-last-path
+          (denote--path title kws directory id 'org))
+    (denote--keywords-add-to-history kws)
+    (concat front-matter template denote-org-capture-specifiers)))
+
+(defun denote-org-capture-delete-empty-file ()
+  "Delete file if capture with `denote-org-capture' is aborted."
+  (when-let* ((file denote-last-path)
+              ((denote--file-empty-p file)))
+    (delete-file denote-last-path)))
+
+(add-hook 'org-capture-after-finalize-hook #'denote-org-capture-delete-empty-file)
+
+(make-obsolete 'denote-migrate-old-org-filetags nil "1.1.0")
+(make-obsolete 'denote-migrate-old-markdown-yaml-tags nil "1.1.0")
+
+;;;; Denote extension "modules"
+
+(defvar denote-modules-available
+  '(project (project-find-functions . denote-project-find)
+            xref    (xref-backend-functions . denote--xref-backend)
+            ffap    (denote-module-ffap-enable . denote-module-ffap-disable))
+  "Denote modules currently built-in with Denote.
+This variable is a plist.  Each module is represented as a pair
+of a property name and its value being a cons cell; thus a module
+is written in either the following forms:
+
+    NAME (HOOK . FUNCTION\)
+    NAME (FUNCTION . FUNCTION\)
+
+NAME, HOOK, FUNCTION are symbols.
+
+When a HOOK-FUNCTION pair is used, `denote-modules-enable'
+function will add FUNCTION to HOOK and `denote-modules-disable'
+function will remove FUNCTION from HOOK.  Generally, it should be
+possible to set HOOK-FUNCTION modules locally.
+
+When a FUNCTION-FUNCTION pair is used, the first FUNCTION must be
+an enable function and the second, its corresponding disable
+function to undo the former.  They are both called with no
+arguments.  For FUNCTION-FUNCTION modules, in some cases, it may
+not be possible to enable a module locally.  In these cases, some
+parts of a module may be enabled globally even when local minor
+mode function `denote-modules-mode' is called.
+
+NOTES for future development to add new modules:
+
+It is important that FUNCTION must be defined and loaded before
+`denote-modules-enable' and `denote-moduel-disable' (the new
+functions probably should be written in the source code lines
+before these enable/disable functions)")
+
+(defvar denote-module-ffap-last-enabled nil
+  "Value of `ffap-next-regexp' beofe ffap module was last enabled.
+It is used by `denote-module-ffap-disable' to undo the value
+the module previoulsy set.")
+
+(defvar denote-modules-last-enabled nil
+  "Denote modules set last time.
+It is used by `denote-modules-enable' and
+`denote-moduules-disable' to undo the modules enabled last time.")
+
+;; defvars to placate the compilers
+(defvar denote-modules)
+(defvar ffap-next-regexp)
+(defvar ffap-alist)
+
+(defun denote-module-ffap-disable (&optional local)
+  "Disable Denote integration with `ffap'.
+This function is meant to be set as a pair function with
+`denote-module-ffap-enable' in `denote-modules-available'.
+
+When LOCAL is non-nil, enable only for the local buffer as
+much as possible.  Currently, `ffap-alist' is only disabled
+globally."
+  (require 'ffap)
+  (setq ffap-alist (rassq-delete-all  #'denote-get-relative-path-by-id ffap-alist))
+  (if local
+      (when denote-module-ffap-last-enabled
+        (setq-local ffap-next-regexp denote-module-ffap-last-enabled))
+    ;; Reset `ffap-next-regexp' only when there is last-active.  Nil
+    ;; means it is in the loading process of denote
+    (when denote-module-ffap-last-enabled
+      (setq ffap-next-regexp denote-module-ffap-last-enabled))))
+
+(defun denote-module-ffap-enable (&optional local)
+  "Enable Denote integration with `ffap'.
+This function is meant to be set as a pair function with
+`denote-module-ffap-disable' in `denote-modules-available'.
+
+When LOCAL is non-nil, enable only for the local buffer as much
+as possible.  Currently, `'ffap-alist' is only enabled globally."
+  (require 'ffap)
+  (if local (setq-local denote-module-ffap-last-active ffap-next-regexp)
+    (setq denote-module-ffap-last-enabled ffap-next-regexp)
+    (add-to-list 'ffap-alist (cons denote-id-regexp #'denote-get-relative-path-by-id)))
+  (if local
+      (setq-local ffap-next-regexp (concat ffap-next-regexp "\\|" denote-id-regexp))
+    (setq ffap-next-regexp (concat ffap-next-regexp "\\|" denote-id-regexp))))
+
+(defun denote-modules-disable (modules &optional local)
+  "Disable Denote integration MODULES.
+This function is meant to be used by `denote-modules-enable',
+which calls this function, passgin `denote-modules-last-enable'
+as MODULES to undo the modules currently active.
+
+When LOCAL is non-nil, disable MODULES locally, where possible.
+
+Refer to document string of `denote-modules-available'."
+  (dolist (module modules)
+    (let* ((module-def (plist-get denote-modules-available module))
+           (hook (car module-def))
+           (func (cdr module-def)))
+      ;; If HOOK is a function, it's a setup function and FUNC is its
+      ;; teardown counterpart.
+      (if (functionp hook) (funcall func local)
+        (remove-hook hook func local)))))
+
+(defun denote-modules-enable (modules &optional local)
+  "Enable MODULES set in `denote-modules'.
+When LOCAL is non-nil, it tries to enable them only locally.
+Whether this is possible or not depends on the module in
+question.
+
+Refer to document string of `denote-modules-available'."
+  (denote-modules-disable denote-modules-last-enabled)
+  (dolist (module modules)
+    (let* ((module-def (plist-get denote-modules-available module))
+           (hook (car module-def))
+           (func (cdr module-def)))
+      ;; If HOOK is a function, it's a setup function and FUNC is its
+      ;; teardown counterpart.
+      (if (functionp hook) (funcall hook local)
+        (add-hook hook func nil local))))
+  (if local (setq denote-modules-last-enabled modules)
+    (setq denote-modules-last-enabled modules)))
+
+;;;###autoload
+(define-minor-mode denote-modules-mode
+  "Enable Denote integration modules locally.
+Set modules to be enabled in `denote-modules' and activate the
+minor mode, either globally or locally.  The selected modules are
+enabled only when the minor mode is active."
+  :global nil
+  :init-value nil
+  (if denote-modules-mode
+      (denote-modules-enable denote-modules :local)
+    (denote-modules-disable denote-modules-last-enabled :local)))
+
+;;;###autoload
+(define-minor-mode denote-modules-global-mode
+  "Enable Denote integration modules globally.
+Set modules to be enabled in `denote-modules' and activate the
+minor mode, either globally or locally.  The selected modules are
+enabled only when the minor mode is active."
+  :global t
+  :init-value nil
+  (if denote-modules-global-mode
+      (denote-modules-enable denote-modules)
+    (denote-modules-disable denote-modules-last-enabled)))
+
+(defun denote-modules-set (symbol value)
+  "Set SYMBOL and VALUE for `denote-modules' upon customizing.
+Enable the modules set when `denote-modules-mode' or
+`denote-modules-global-mode' is active.  If not, this function
+does not enable them automatically.  Manually call the minor mode
+globally or locally or set it in your configuration.
+
+It is meant to be used `defcustom' of `denote-modules', thus when
+the minor mode is active, changing the modules in the `customize'
+UI will be effective immediately."
+  (set symbol value)
+  (when (or denote-modules-global-mode denote-modules-mode)
+    (denote-modules-enable value)))
+
+(defcustom denote-modules nil
+  "User-selected Denote modules.
+The selected modules are a list of NAME (symbols), and each
+module enables integration with another Emacs built-in feature.
+See `denote-modules-available' for the modules currently
+available.  Set this user option as a list of NAME; for example:
+
+    (project xref ffap)
+
+When customized in Customize UI, it presents a set of checkboxes,
+each box checked adds NAME of the module to the list.
+
+Modules are automatically enabled only when either
+`denote-modules-mode' or `denote-modules-global-mode' is active.
+If not, setting the modules does not enable or disable them
+automatically.  Manually call the minor mode globally or locally
+or set it in your configuration."
+  :group 'denote
+  :set #'denote-modules-set
+  :package-version '(denote . "1.2.0")
+  :type
+  '(set (const :tag "Project integration" project)
+        (const :tag "Xref integration " xref)
+        (const :tag "Integration with find-file-at-point `ffap'" ffap)))
+
+;;;; project.el integration
+;;   This is also used by xref integration
+
+(cl-defmethod project-root ((project (head denote)))
+  "Denote's implementation of `project-root' method from `project'.
+Return current variable `denote-directory' as the root of the
+current denote PROJECT."
+  (cdr project))
+
+(cl-defmethod project-files ((_project (head denote)) &optional _dirs)
+  "Denote's implementation of `project-files' method from `project'.
+Return all files that have an identifier for the current denote
+PROJECT.  The return value may thus include file types that are
+not implied by `denote-file-type'.  To limit the return value to
+text files, use the function `denote-directory-text-only-files'."
+  (denote-directory-files))
+
+(defun denote-project-find (dir)
+  "Return project instance if DIR is part of variable `denote-directory'.
+The format of project instance is aligned with `project-try-vc'
+defined in `project'."
+  (let ((dir (expand-file-name dir)) ; canonicalize current directory name
+        (root (denote-directory)))
+    (when (or (file-equal-p dir root) ; currently at `denote-directory'
+              (string-prefix-p root dir)) ; or its subdirectory
+      (cons 'denote root))))
+
+;;;; Xref integration
+;;   Set `xref-backend-functions' like this.
+;;     (add-hook 'xref-backend-functions #'denote--xref-backend)
+;;
+;;   You can tell xref-references not to prompt by adding the following:
+;;     (add-to-list 'xref-prompt-for-identifier #'xref-find-references
+;;     :append)
+
+(defun denote--xref-backend ()
+  "Return denote if `default-directory' is in denote directory."
+  (when (denote--dir-in-denote-directory-p default-directory)
+    'denote))
+
+(cl-defmethod xref-backend-identifier-at-point ((_backend (eql 'denote)))
+  "Return the \"thing\" at point.
+The same logic as `elisp-mode'.  The \"thing\" is assumed to be a
+Denote identifier, but can be any word.  The method checks this
+and errors and if the word at point is not a Denote identifier."
+  (let ((bounds (bounds-of-thing-at-point 'word)))
+    (and bounds
+         (let ((id (buffer-substring-no-properties
+                    (car bounds) (cdr bounds))))
+           (if (string-match-p denote-id-regexp id)
+               ;; Use a property to transport the location of the identifier.
+               (propertize id 'pos (car bounds))
+             (user-error "%s is not a Denote identifier" id))))))
+
+(cl-defmethod xref-backend-definitions ((_backend (eql 'denote)) identifier)
+  "Return xref for the note IDENTIFIER points to."
+  (let ((file (denote-get-path-by-id identifier)))
+    (when file
+      (if (file-equal-p file (buffer-file-name (current-buffer)))
+          (user-error "Identifier points to the current buffer")
+        ;; Without the message, Xref will report that the ID does not
+        ;; exist, which is incorrect in this case.
+        (list (xref-make nil (xref-make-file-location file 0 0)))))))
+
+(cl-defmethod xref-backend-references ((_backend (eql 'denote)) identifier)
+  "Return list of xrefs where IDENTIFIER is referenced.
+This include the definition itself."
+  (xref-matches-in-files identifier (denote-directory-text-only-files)))
+
+(cl-defmethod xref-backend-identifier-completion-table ((_backend
+                                                         (eql 'denote)))
+  "Return list of Denote identifers as completion table."
+
+  (mapcar #'denote-retrieve-filename-identifier (denote-all-files)))
+
+(provide 'denote)
+;;; denote.el ends here

--- a/vendor/denote-2.0.0/doclicense.texi
+++ b/vendor/denote-2.0.0/doclicense.texi
@@ -1,0 +1,505 @@
+@c The GNU Free Documentation License.
+@center Version 1.3, 3 November 2008
+
+@c This file is intended to be included within another document,
+@c hence no sectioning command or @node.
+
+@display
+Copyright @copyright{} 2000, 2001, 2002, 2007, 2008 Free Software Foundation, Inc.
+@uref{https://fsf.org/}
+
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+@end display
+
+@enumerate 0
+@item
+PREAMBLE
+
+The purpose of this License is to make a manual, textbook, or other
+functional and useful document @dfn{free} in the sense of freedom: to
+assure everyone the effective freedom to copy and redistribute it,
+with or without modifying it, either commercially or noncommercially.
+Secondarily, this License preserves for the author and publisher a way
+to get credit for their work, while not being considered responsible
+for modifications made by others.
+
+This License is a kind of ``copyleft'', which means that derivative
+works of the document must themselves be free in the same sense.  It
+complements the GNU General Public License, which is a copyleft
+license designed for free software.
+
+We have designed this License in order to use it for manuals for free
+software, because free software needs free documentation: a free
+program should come with manuals providing the same freedoms that the
+software does.  But this License is not limited to software manuals;
+it can be used for any textual work, regardless of subject matter or
+whether it is published as a printed book.  We recommend this License
+principally for works whose purpose is instruction or reference.
+
+@item
+APPLICABILITY AND DEFINITIONS
+
+This License applies to any manual or other work, in any medium, that
+contains a notice placed by the copyright holder saying it can be
+distributed under the terms of this License.  Such a notice grants a
+world-wide, royalty-free license, unlimited in duration, to use that
+work under the conditions stated herein.  The ``Document'', below,
+refers to any such manual or work.  Any member of the public is a
+licensee, and is addressed as ``you''.  You accept the license if you
+copy, modify or distribute the work in a way requiring permission
+under copyright law.
+
+A ``Modified Version'' of the Document means any work containing the
+Document or a portion of it, either copied verbatim, or with
+modifications and/or translated into another language.
+
+A ``Secondary Section'' is a named appendix or a front-matter section
+of the Document that deals exclusively with the relationship of the
+publishers or authors of the Document to the Document's overall
+subject (or to related matters) and contains nothing that could fall
+directly within that overall subject.  (Thus, if the Document is in
+part a textbook of mathematics, a Secondary Section may not explain
+any mathematics.)  The relationship could be a matter of historical
+connection with the subject or with related matters, or of legal,
+commercial, philosophical, ethical or political position regarding
+them.
+
+The ``Invariant Sections'' are certain Secondary Sections whose titles
+are designated, as being those of Invariant Sections, in the notice
+that says that the Document is released under this License.  If a
+section does not fit the above definition of Secondary then it is not
+allowed to be designated as Invariant.  The Document may contain zero
+Invariant Sections.  If the Document does not identify any Invariant
+Sections then there are none.
+
+The ``Cover Texts'' are certain short passages of text that are listed,
+as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+the Document is released under this License.  A Front-Cover Text may
+be at most 5 words, and a Back-Cover Text may be at most 25 words.
+
+A ``Transparent'' copy of the Document means a machine-readable copy,
+represented in a format whose specification is available to the
+general public, that is suitable for revising the document
+straightforwardly with generic text editors or (for images composed of
+pixels) generic paint programs or (for drawings) some widely available
+drawing editor, and that is suitable for input to text formatters or
+for automatic translation to a variety of formats suitable for input
+to text formatters.  A copy made in an otherwise Transparent file
+format whose markup, or absence of markup, has been arranged to thwart
+or discourage subsequent modification by readers is not Transparent.
+An image format is not Transparent if used for any substantial amount
+of text.  A copy that is not ``Transparent'' is called ``Opaque''.
+
+Examples of suitable formats for Transparent copies include plain
+ASCII without markup, Texinfo input format, La@TeX{} input
+format, SGML or XML using a publicly available
+DTD, and standard-conforming simple HTML,
+PostScript or PDF designed for human modification.  Examples
+of transparent image formats include PNG, XCF and
+JPG@.  Opaque formats include proprietary formats that can be
+read and edited only by proprietary word processors, SGML or
+XML for which the DTD and/or processing tools are
+not generally available, and the machine-generated HTML,
+PostScript or PDF produced by some word processors for
+output purposes only.
+
+The ``Title Page'' means, for a printed book, the title page itself,
+plus such following pages as are needed to hold, legibly, the material
+this License requires to appear in the title page.  For works in
+formats which do not have any title page as such, ``Title Page'' means
+the text near the most prominent appearance of the work's title,
+preceding the beginning of the body of the text.
+
+The ``publisher'' means any person or entity that distributes copies
+of the Document to the public.
+
+A section ``Entitled XYZ'' means a named subunit of the Document whose
+title either is precisely XYZ or contains XYZ in parentheses following
+text that translates XYZ in another language.  (Here XYZ stands for a
+specific section name mentioned below, such as ``Acknowledgements'',
+``Dedications'', ``Endorsements'', or ``History''.)  To ``Preserve the Title''
+of such a section when you modify the Document means that it remains a
+section ``Entitled XYZ'' according to this definition.
+
+The Document may include Warranty Disclaimers next to the notice which
+states that this License applies to the Document.  These Warranty
+Disclaimers are considered to be included by reference in this
+License, but only as regards disclaiming warranties: any other
+implication that these Warranty Disclaimers may have is void and has
+no effect on the meaning of this License.
+
+@item
+VERBATIM COPYING
+
+You may copy and distribute the Document in any medium, either
+commercially or noncommercially, provided that this License, the
+copyright notices, and the license notice saying this License applies
+to the Document are reproduced in all copies, and that you add no other
+conditions whatsoever to those of this License.  You may not use
+technical measures to obstruct or control the reading or further
+copying of the copies you make or distribute.  However, you may accept
+compensation in exchange for copies.  If you distribute a large enough
+number of copies you must also follow the conditions in section 3.
+
+You may also lend copies, under the same conditions stated above, and
+you may publicly display copies.
+
+@item
+COPYING IN QUANTITY
+
+If you publish printed copies (or copies in media that commonly have
+printed covers) of the Document, numbering more than 100, and the
+Document's license notice requires Cover Texts, you must enclose the
+copies in covers that carry, clearly and legibly, all these Cover
+Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on
+the back cover.  Both covers must also clearly and legibly identify
+you as the publisher of these copies.  The front cover must present
+the full title with all words of the title equally prominent and
+visible.  You may add other material on the covers in addition.
+Copying with changes limited to the covers, as long as they preserve
+the title of the Document and satisfy these conditions, can be treated
+as verbatim copying in other respects.
+
+If the required texts for either cover are too voluminous to fit
+legibly, you should put the first ones listed (as many as fit
+reasonably) on the actual cover, and continue the rest onto adjacent
+pages.
+
+If you publish or distribute Opaque copies of the Document numbering
+more than 100, you must either include a machine-readable Transparent
+copy along with each Opaque copy, or state in or with each Opaque copy
+a computer-network location from which the general network-using
+public has access to download using public-standard network protocols
+a complete Transparent copy of the Document, free of added material.
+If you use the latter option, you must take reasonably prudent steps,
+when you begin distribution of Opaque copies in quantity, to ensure
+that this Transparent copy will remain thus accessible at the stated
+location until at least one year after the last time you distribute an
+Opaque copy (directly or through your agents or retailers) of that
+edition to the public.
+
+It is requested, but not required, that you contact the authors of the
+Document well before redistributing any large number of copies, to give
+them a chance to provide you with an updated version of the Document.
+
+@item
+MODIFICATIONS
+
+You may copy and distribute a Modified Version of the Document under
+the conditions of sections 2 and 3 above, provided that you release
+the Modified Version under precisely this License, with the Modified
+Version filling the role of the Document, thus licensing distribution
+and modification of the Modified Version to whoever possesses a copy
+of it.  In addition, you must do these things in the Modified Version:
+
+@enumerate A
+@item
+Use in the Title Page (and on the covers, if any) a title distinct
+from that of the Document, and from those of previous versions
+(which should, if there were any, be listed in the History section
+of the Document).  You may use the same title as a previous version
+if the original publisher of that version gives permission.
+
+@item
+List on the Title Page, as authors, one or more persons or entities
+responsible for authorship of the modifications in the Modified
+Version, together with at least five of the principal authors of the
+Document (all of its principal authors, if it has fewer than five),
+unless they release you from this requirement.
+
+@item
+State on the Title page the name of the publisher of the
+Modified Version, as the publisher.
+
+@item
+Preserve all the copyright notices of the Document.
+
+@item
+Add an appropriate copyright notice for your modifications
+adjacent to the other copyright notices.
+
+@item
+Include, immediately after the copyright notices, a license notice
+giving the public permission to use the Modified Version under the
+terms of this License, in the form shown in the Addendum below.
+
+@item
+Preserve in that license notice the full lists of Invariant Sections
+and required Cover Texts given in the Document's license notice.
+
+@item
+Include an unaltered copy of this License.
+
+@item
+Preserve the section Entitled ``History'', Preserve its Title, and add
+to it an item stating at least the title, year, new authors, and
+publisher of the Modified Version as given on the Title Page.  If
+there is no section Entitled ``History'' in the Document, create one
+stating the title, year, authors, and publisher of the Document as
+given on its Title Page, then add an item describing the Modified
+Version as stated in the previous sentence.
+
+@item
+Preserve the network location, if any, given in the Document for
+public access to a Transparent copy of the Document, and likewise
+the network locations given in the Document for previous versions
+it was based on.  These may be placed in the ``History'' section.
+You may omit a network location for a work that was published at
+least four years before the Document itself, or if the original
+publisher of the version it refers to gives permission.
+
+@item
+For any section Entitled ``Acknowledgements'' or ``Dedications'', Preserve
+the Title of the section, and preserve in the section all the
+substance and tone of each of the contributor acknowledgements and/or
+dedications given therein.
+
+@item
+Preserve all the Invariant Sections of the Document,
+unaltered in their text and in their titles.  Section numbers
+or the equivalent are not considered part of the section titles.
+
+@item
+Delete any section Entitled ``Endorsements''.  Such a section
+may not be included in the Modified Version.
+
+@item
+Do not retitle any existing section to be Entitled ``Endorsements'' or
+to conflict in title with any Invariant Section.
+
+@item
+Preserve any Warranty Disclaimers.
+@end enumerate
+
+If the Modified Version includes new front-matter sections or
+appendices that qualify as Secondary Sections and contain no material
+copied from the Document, you may at your option designate some or all
+of these sections as invariant.  To do this, add their titles to the
+list of Invariant Sections in the Modified Version's license notice.
+These titles must be distinct from any other section titles.
+
+You may add a section Entitled ``Endorsements'', provided it contains
+nothing but endorsements of your Modified Version by various
+parties---for example, statements of peer review or that the text has
+been approved by an organization as the authoritative definition of a
+standard.
+
+You may add a passage of up to five words as a Front-Cover Text, and a
+passage of up to 25 words as a Back-Cover Text, to the end of the list
+of Cover Texts in the Modified Version.  Only one passage of
+Front-Cover Text and one of Back-Cover Text may be added by (or
+through arrangements made by) any one entity.  If the Document already
+includes a cover text for the same cover, previously added by you or
+by arrangement made by the same entity you are acting on behalf of,
+you may not add another; but you may replace the old one, on explicit
+permission from the previous publisher that added the old one.
+
+The author(s) and publisher(s) of the Document do not by this License
+give permission to use their names for publicity for or to assert or
+imply endorsement of any Modified Version.
+
+@item
+COMBINING DOCUMENTS
+
+You may combine the Document with other documents released under this
+License, under the terms defined in section 4 above for modified
+versions, provided that you include in the combination all of the
+Invariant Sections of all of the original documents, unmodified, and
+list them all as Invariant Sections of your combined work in its
+license notice, and that you preserve all their Warranty Disclaimers.
+
+The combined work need only contain one copy of this License, and
+multiple identical Invariant Sections may be replaced with a single
+copy.  If there are multiple Invariant Sections with the same name but
+different contents, make the title of each such section unique by
+adding at the end of it, in parentheses, the name of the original
+author or publisher of that section if known, or else a unique number.
+Make the same adjustment to the section titles in the list of
+Invariant Sections in the license notice of the combined work.
+
+In the combination, you must combine any sections Entitled ``History''
+in the various original documents, forming one section Entitled
+``History''; likewise combine any sections Entitled ``Acknowledgements'',
+and any sections Entitled ``Dedications''.  You must delete all
+sections Entitled ``Endorsements.''
+
+@item
+COLLECTIONS OF DOCUMENTS
+
+You may make a collection consisting of the Document and other documents
+released under this License, and replace the individual copies of this
+License in the various documents with a single copy that is included in
+the collection, provided that you follow the rules of this License for
+verbatim copying of each of the documents in all other respects.
+
+You may extract a single document from such a collection, and distribute
+it individually under this License, provided you insert a copy of this
+License into the extracted document, and follow this License in all
+other respects regarding verbatim copying of that document.
+
+@item
+AGGREGATION WITH INDEPENDENT WORKS
+
+A compilation of the Document or its derivatives with other separate
+and independent documents or works, in or on a volume of a storage or
+distribution medium, is called an ``aggregate'' if the copyright
+resulting from the compilation is not used to limit the legal rights
+of the compilation's users beyond what the individual works permit.
+When the Document is included in an aggregate, this License does not
+apply to the other works in the aggregate which are not themselves
+derivative works of the Document.
+
+If the Cover Text requirement of section 3 is applicable to these
+copies of the Document, then if the Document is less than one half of
+the entire aggregate, the Document's Cover Texts may be placed on
+covers that bracket the Document within the aggregate, or the
+electronic equivalent of covers if the Document is in electronic form.
+Otherwise they must appear on printed covers that bracket the whole
+aggregate.
+
+@item
+TRANSLATION
+
+Translation is considered a kind of modification, so you may
+distribute translations of the Document under the terms of section 4.
+Replacing Invariant Sections with translations requires special
+permission from their copyright holders, but you may include
+translations of some or all Invariant Sections in addition to the
+original versions of these Invariant Sections.  You may include a
+translation of this License, and all the license notices in the
+Document, and any Warranty Disclaimers, provided that you also include
+the original English version of this License and the original versions
+of those notices and disclaimers.  In case of a disagreement between
+the translation and the original version of this License or a notice
+or disclaimer, the original version will prevail.
+
+If a section in the Document is Entitled ``Acknowledgements'',
+``Dedications'', or ``History'', the requirement (section 4) to Preserve
+its Title (section 1) will typically require changing the actual
+title.
+
+@item
+TERMINATION
+
+You may not copy, modify, sublicense, or distribute the Document
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense, or distribute it is void, and
+will automatically terminate your rights under this License.
+
+However, if you cease all violation of this License, then your license
+from a particular copyright holder is reinstated (a) provisionally,
+unless and until the copyright holder explicitly and finally
+terminates your license, and (b) permanently, if the copyright holder
+fails to notify you of the violation by some reasonable means prior to
+60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, receipt of a copy of some or all of the same material does
+not give you any rights to use it.
+
+@item
+FUTURE REVISIONS OF THIS LICENSE
+
+The Free Software Foundation may publish new, revised versions
+of the GNU Free Documentation License from time to time.  Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.  See
+@uref{https://www.gnu.org/licenses/}.
+
+Each version of the License is given a distinguishing version number.
+If the Document specifies that a particular numbered version of this
+License ``or any later version'' applies to it, you have the option of
+following the terms and conditions either of that specified version or
+of any later version that has been published (not as a draft) by the
+Free Software Foundation.  If the Document does not specify a version
+number of this License, you may choose any version ever published (not
+as a draft) by the Free Software Foundation.  If the Document
+specifies that a proxy can decide which future versions of this
+License can be used, that proxy's public statement of acceptance of a
+version permanently authorizes you to choose that version for the
+Document.
+
+@item
+RELICENSING
+
+``Massive Multiauthor Collaboration Site'' (or ``MMC Site'') means any
+World Wide Web server that publishes copyrightable works and also
+provides prominent facilities for anybody to edit those works.  A
+public wiki that anybody can edit is an example of such a server.  A
+``Massive Multiauthor Collaboration'' (or ``MMC'') contained in the
+site means any set of copyrightable works thus published on the MMC
+site.
+
+``CC-BY-SA'' means the Creative Commons Attribution-Share Alike 3.0
+license published by Creative Commons Corporation, a not-for-profit
+corporation with a principal place of business in San Francisco,
+California, as well as future copyleft versions of that license
+published by that same organization.
+
+``Incorporate'' means to publish or republish a Document, in whole or
+in part, as part of another Document.
+
+An MMC is ``eligible for relicensing'' if it is licensed under this
+License, and if all works that were first published under this License
+somewhere other than this MMC, and subsequently incorporated in whole
+or in part into the MMC, (1) had no cover texts or invariant sections,
+and (2) were thus incorporated prior to November 1, 2008.
+
+The operator of an MMC Site may republish an MMC contained in the site
+under CC-BY-SA on the same site at any time before August 1, 2009,
+provided the MMC is eligible for relicensing.
+
+@end enumerate
+
+@page
+@heading ADDENDUM: How to use this License for your documents
+
+To use this License in a document you have written, include a copy of
+the License in the document and put the following copyright and
+license notices just after the title page:
+
+@smallexample
+@group
+  Copyright (C)  @var{year}  @var{your name}.
+  Permission is granted to copy, distribute and/or modify this document
+  under the terms of the GNU Free Documentation License, Version 1.3
+  or any later version published by the Free Software Foundation;
+  with no Invariant Sections, no Front-Cover Texts, and no Back-Cover
+  Texts.  A copy of the license is included in the section entitled ``GNU
+  Free Documentation License''.
+@end group
+@end smallexample
+
+If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts,
+replace the ``with@dots{}Texts.''@: line with this:
+
+@smallexample
+@group
+    with the Invariant Sections being @var{list their titles}, with
+    the Front-Cover Texts being @var{list}, and with the Back-Cover Texts
+    being @var{list}.
+@end group
+@end smallexample
+
+If you have Invariant Sections without Cover Texts, or some other
+combination of the three, merge those two alternatives to suit the
+situation.
+
+If your document contains nontrivial examples of program code, we
+recommend releasing these examples in parallel under your choice of
+free software license, such as the GNU General Public License,
+to permit their use in free software.
+
+@c Local Variables:
+@c ispell-local-pdict: "ispell-dict"
+@c End:

--- a/vendor/denote-2.0.0/tests/denote-test.el
+++ b/vendor/denote-2.0.0/tests/denote-test.el
@@ -1,0 +1,237 @@
+;;; denote-test.el --- Unit tests for Denote -*- lexical-binding: t -*-
+
+;; Copyright (C) 2023  Free Software Foundation, Inc.
+
+;; Author: Protesilaos Stavrou <info@protesilaos.com>
+;; Maintainer: Denote Development <~protesilaos/denote@lists.sr.ht>
+;; URL: https://git.sr.ht/~protesilaos/denote
+;; Mailing-List: https://lists.sr.ht/~protesilaos/denote
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; WORK-IN-PROGRESS
+
+;;; Code:
+
+(require 'ert)
+(require 'denote)
+
+;; TODO 2023-05-22: Incorporate an actual silo in this test directory
+;; and modify the test accordingly.
+(ert-deftest denote-test-denote--default-directory-is-silo-p ()
+  "Test that `denote--default-directory-is-silo-p' returns a path."
+  (let ((path (denote--default-directory-is-silo-p)))
+    (should (or (null path)
+                (and (stringp path)
+                     (file-exists-p path)
+                     (file-directory-p path))))))
+
+(ert-deftest denote-test--denote--make-denote-directory ()
+  "Test that `denote--make-denote-directory' creates the directory."
+  (should (null (denote--make-denote-directory))))
+
+(ert-deftest denote-test--denote-directory ()
+  "Test that variable `denote-directory' returns an absolute directory name."
+  (let ((path (denote-directory)))
+    (should (and (file-directory-p path)
+                 (file-name-absolute-p path)))))
+
+(ert-deftest denote-test--denote--slug-no-punct ()
+  "Test that `denote--slug-no-punct' removes punctuation from the string.
+Concretely, replace with spaces anything that matches the
+`denote-excluded-punctuation-regexp' and
+`denote-excluded-punctuation-extra-regexp'."
+  (should (equal (denote--slug-no-punct "This is !@# test")
+                 "This is  test")))
+
+(ert-deftest denote-test--denote--slug-hyphenate ()
+  "Test that `denote--slug-hyphenate' hyphenates the string.
+Also replace multiple hyphens with a single one and remove any
+leading and trailing hyphen."
+  (should (equal (denote--slug-hyphenate "__  This is   a    test  __  ")
+                 "This-is-a-test")))
+
+(ert-deftest denote-test--denote-sluggify ()
+  "Test that `denote-sluggify' sluggifies the string.
+To sluggify is to (i) downcase, (ii) hyphenate, (iii) de-punctuate, and (iv) remove spaces from the string."
+  (should (equal (denote-sluggify " ___ !~!!$%^ This iS a tEsT ++ ?? ")
+                 "this-is-a-test")))
+
+(ert-deftest denote-test--denote--slug-put-equals ()
+  "Test that `denote--slug-put-equals' replaces spaces/underscores with =.
+Otherwise do the same as what is described in
+`denote-test--denote--slug-hyphenate'.
+
+The use of the equals sign is for the SIGNATURE field of the
+Denote file name."
+  (should (equal (denote--slug-put-equals "__  This is   a    test  __  ")
+                 "This=is=a=test")))
+
+(ert-deftest denote-test--denote-sluggify-signature ()
+  "Test that `denote-sluggify-signature' sluggifies the string for file signatures.
+This is like `denote-test--denote-sluggify', except that it also
+accounts for what we describe in `denote-test--denote--slug-put-equals'."
+  (should (equal (denote-sluggify-signature " ___ !~!!$%^ This iS a tEsT ++ ?? ")
+                 "this=is=a=test")))
+
+(ert-deftest denote-test--denote-sluggify-and-join ()
+  "Test that `denote-sluggify-and-join' sluggifies the string while joining words.
+In this context, to join words is to elimitate any space or
+delimiter between them.
+
+Otherwise, this is like `denote-test--denote-sluggify'."
+  (should (equal (denote-sluggify-and-join " ___ !~!!$%^ This iS a tEsT ++ ?? ")
+                 "thisisatest")))
+
+(ert-deftest denote-test--denote-sluggify-keywords ()
+  "Test that `denote-sluggify-keywords' sluggifies a list of strings.
+The function also account for the value of the user option
+`denote-allow-multi-word-keywords'."
+  (should
+   (let ((denote-allow-multi-word-keywords nil))
+     (equal (denote-sluggify-keywords '("one !@# one" "   two" "__  three  __"))
+            '("oneone" "two" "three"))))
+  (should
+   (let ((denote-allow-multi-word-keywords t))
+     (equal (denote-sluggify-keywords '("one !@# one" "   two" "__  three  __"))
+            '("one-one" "two" "three")))))
+
+(ert-deftest denote-test--denote-desluggify ()
+  "Test that `denote-desluggify' upcases first character and de-hyphenates string."
+  (should (equal (denote-desluggify "this-is-a-test") "This is a test"))
+  (should (null (equal (denote-desluggify "this=is=a=test") "This is a test"))))
+
+(ert-deftest denote-test--denote--file-empty-p ()
+  "Test that `denote--file-empty-p' returns non-nil on empty file."
+  ;; (should (null (denote--file-empty-p user-init-file))
+  (should (let ((file (make-temp-file "denote-test")))
+            (prog1
+                (denote--file-empty-p file)
+              (delete-file file)))))
+
+(ert-deftest denote-test--denote-file-is-note-p ()
+  "Test that `denote-file-is-note-p' checks that files is a Denote note.
+For our purposes, a note must note be a directory, must satisfy
+`file-regular-p', its path must be part of the variable
+`denote-directory', it must have a Denote identifier in its name,
+and use one of the extensions implied by `denote-file-type'."
+  (should (let* ((tmp (temporary-file-directory))
+                 (denote-directory tmp)
+                 (file (concat tmp "20230522T154900--test__keyword.txt")))
+            (with-current-buffer (find-file-noselect file)
+              (write-file file))
+            (prog1
+                (denote-file-is-note-p file)
+              (delete-file file)))))
+
+(ert-deftest denote-test--denote-file-has-identifier-p ()
+  "Test that `denote-file-has-identifier-p' checks for a Denote identifier."
+  (should (denote-file-has-identifier-p "20230522T154900--test__keyword.txt"))
+  (should (null (denote-file-has-identifier-p "T154900--test__keyword.txt"))))
+
+(ert-deftest denote-test--denote-file-has-signature-p ()
+  "Test that `denote-file-has-signature-p' checks for a Denote signature."
+  (should (denote-file-has-signature-p "20230522T154900==sig--test__keyword.txt"))
+  (should (null (denote-file-has-signature-p "20230522T154900--test__keyword.txt"))))
+
+(ert-deftest denote-test--denote-file-has-supported-extension-p ()
+  "Test that `denote-file-has-supported-extension-p' matches a supported extension."
+  (should
+   (member
+    (file-name-extension "20230522T154900==sig--test__keyword.txt" :period)
+    (denote-file-type-extensions-with-encryption)))
+  (should
+   (null
+    (member
+     (file-name-extension "20230522T154900==sig--test__keyword" :period)
+     (denote-file-type-extensions-with-encryption)))))
+
+(ert-deftest denote-test--denote-file-type-extensions ()
+  "Test that `denote-file-type-extensions' returns file extensions.
+We check for the common file type extensions, though the user can
+theoretically set `denote-file-types' to nil and handle things on
+their own.  We do not have to test for that scenario, because
+such a user will be redefining large parts of Denote's behaviour
+with regard to file types."
+  (let ((extensions (denote-file-type-extensions)))
+    (should (or (member ".md" extensions)
+                (member ".org" extensions)
+                (member ".txt" extensions)))))
+
+(ert-deftest denote-test--denote-file-type-extensions-with-encryption ()
+  "Test that `denote-file-type-extensions-with-encryption' covers encryption.
+Extend what we do in `denote-test--denote-file-type-extensions'."
+  (let ((extensions (denote-file-type-extensions-with-encryption)))
+    (should (or (member ".md" extensions)
+                (member ".org" extensions)
+                (member ".txt" extensions)
+                (member ".md.gpg" extensions)
+                (member ".org.gpg" extensions)
+                (member ".txt.gpg" extensions)
+                (member ".md.age" extensions)
+                (member ".org.age" extensions)
+                (member ".txt.age" extensions)))))
+
+(ert-deftest denote-test--denote--format-front-matter ()
+  "Test that `denote--format-front-matter' formats front matter correctly."
+  (should (and (equal (denote--format-front-matter "" "" '("") "" 'text)
+                      "title:      
+date:       
+tags:       
+identifier: 
+---------------------------
+
+")
+               (equal
+                ;; (denote--format-front-matter
+                ;;  "Some test" (denote--date nil 'org) '("one" "two")
+                ;;  (format-time-string denote-id-format nil) 'org)
+                (denote--format-front-matter
+                 "Some test" "2023-06-05" '("one" "two")
+                 "20230605T102234" 'text)
+                "title:      Some test
+date:       2023-06-05
+tags:       one  two
+identifier: 20230605T102234
+---------------------------
+
+"))))
+
+;; ;; NOTE 2023-06-30: The following needs to be reviewed.
+;;
+;; (ert-deftest denote-test--denote-format-file-name ()
+;;   "Test that `denote-format-file-name' returns all expected paths."
+;;   (let ((title "Some test")
+;;         (id (format-time-string denote-id-format (current-time-string "2023-06-05")))
+;;         (kws '("one" "two"))
+;;         (type 'text))
+;;     (should
+;;      (equal
+;;      (denote-format-file-name
+;;              (denote--path title
+;;                            kws
+;;                            (denote-directory)
+;;                            id
+;;                            type)
+;;              id
+;;              (denote-sluggify-keywords kws)
+;;              (denote-sluggify title)
+;;              (denote--file-extension type))))
+
+(provide 'denote-test)
+;;; denote-test.el ends here


### PR DESCRIPTION
いろいろ解決しないうちに設定追加などしたために色々混じっている

- exwmのバージョン追従 -- exwm-configのコピー
- denoteのバージョン固定 v3にするとファイルリネーム時に2重に表示されてしまうのを解決できなかった
- eglot
- tabnine
- git-gutter のリポジトリ変更に追従